### PR TITLE
plugins-base.txt: add copyartifact

### DIFF
--- a/plugins-base.txt
+++ b/plugins-base.txt
@@ -58,3 +58,4 @@ credentials
 workflow-cps
 job-dsl
 ws-cleanup
+copyartifact


### PR DESCRIPTION
The copyartifact is used to copy artifacts between trigger and runner
jobs, so it is required.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>