### PR TITLE
docker-compose.yaml: only use .env file

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,8 +7,6 @@ services:
     - PLUGINS_FORCE_UPGRADE=true
     env_file:
     - .env
-    - .env-labs
-    - .env-extra
     build: .
     ports:
     - "${JENKINS_PORT:-8080}:8080"


### PR DESCRIPTION
Only use the .env file in docker-compose.yaml as the main one to
provide the values to use with the current deployment.  The other
files are there as examples and when included they override the values
from the .env file.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>