### PR TITLE
T17420 jobs.groovy: add PIPELINE_VERSION to rootfs-builder

### DIFF
--- a/jobs.groovy
+++ b/jobs.groovy
@@ -253,5 +253,6 @@ pipelineJob('rootfs-builder') {
     stringParam('DOCKER_BASE', DOCKER_BASE, 'Dockerhub base address used for the rootfs build images.')
     stringParam('ROOTFS_CONFIG','','Name of the rootfs configuration, all rootfs will be built by default.')
     stringParam('ROOTFS_ARCH','','Name of the rootfs arch config, all given arch will be built by default.')
+    stringParam('PIPELINE_VERSION','','Unique string identifier for the series of rootfs build jobs.')
   }
 }


### PR DESCRIPTION
Add a PIPELINE_VERSION parameter to the rootfs-builder job as this is
required in order to upload the rootfs images in a unique directory on
the storage server.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>