### PR TITLE
jobs.groovy: use KCI_MONITOR_CRON environment variable

### DIFF
--- a/.env-production
+++ b/.env-production
@@ -9,5 +9,7 @@ KCI_STORAGE_URL=https://storage.kernelci.org
 DOCKER_BASE=kernelci/build-
 JENKINS_URL=https://bot.kernelci.org
 
+KCI_MONITOR_CRON='0 * * * *'
+
 ADMIN_PASSWORD=adminpasswordhere
 KCI_API_TOKEN=yourtokenhere

--- a/jobs.groovy
+++ b/jobs.groovy
@@ -10,6 +10,7 @@ def KCI_BISECTION_CALLBACK_ID = System.getenv("KCI_BISECTION_CALLBACK_ID")
 def KCI_BISECTION_EMAIL_RECIPIENTS = System.getenv("KCI_BISECTION_EMAIL_RECIPIENTS")
 def KCI_BISECTION_TREES_WHITELIST = System.getenv("KCI_BISECTION_TREES_WHITELIST")
 def KCI_BISECTION_LABS_WHITELIST = System.getenv("KCI_BISECTION_LABS_WHITELIST")
+def KCI_MONITOR_CRON = System.getenv("KCI_MONITOR_CRON")
 
 pipelineJob('kernel-tree-monitor') {
   definition {
@@ -24,6 +25,11 @@ pipelineJob('kernel-tree-monitor') {
         }
       }
       scriptPath('jenkins/monitor.jpl')
+    }
+    if (KCI_MONITOR_CRON) {
+      triggers {
+        cron(KCI_MONITOR_CRON)
+      }
     }
   }
   parameters {


### PR DESCRIPTION
Add KCI_MONITOR_CRON environment variable to define a cron trigger for
the kernel-tree-monitor job.  If not defined, no periodic trigger will
be set.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>