### PR TITLE
Add jenkins_docker_image argument to choose Jenkins version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM jenkins/jenkins:latest
+ARG jenkins_docker_image=jenkins/jenkins:latest
+FROM $jenkins_docker_image
+
 ARG config=/config
 COPY plugins*.txt /usr/share/jenkins/ref/
 RUN cat /usr/share/jenkins/ref/plugins*.txt | /usr/local/bin/install-plugins.sh

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,6 +10,7 @@ services:
     build:
       context: .
       args:
+        jenkins_docker_image: ${JENKINS_DOCKER_IMAGE:-jenkins/jenkins:latest}
         config: ${CASC_JENKINS_CONFIG_SOURCE:-/config}
     ports:
     - "${JENKINS_PORT:-8080}:8080"


### PR DESCRIPTION
Add a jenkins_docker_image build-time argument to the Dockerfile and
populate it from the JENKINS_DOCKER_IMAGE environment variable in
docker-compose.yaml to be able to choose which Jenkins Docker image to
use.  The default is still set to jenkins/jenkins:latest but for
production instances it's important to be able to set the exact
Jenkins revision to use.  For example, "jenkins/jenkins:2.232".

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>