### PR TITLE
Move jenkins auth settings to separate YAML

### DIFF
--- a/config/default-auth.yaml
+++ b/config/default-auth.yaml
@@ -1,0 +1,11 @@
+jenkins:
+  authorizationStrategy:
+    loggedInUsersCanDoAnything:
+      allowAnonymousRead: true
+  securityRealm:
+    local:
+      allowsSignup: false
+      enableCaptcha: false
+      users:
+      - id: "admin"
+        password: "${ADMIN_PASSWORD}"

--- a/config/jenkins.yaml
+++ b/config/jenkins.yaml
@@ -6,16 +6,6 @@ jenkins:
   scmCheckoutRetryCount: 0
   mode: NORMAL
 
-  authorizationStrategy:
-    loggedInUsersCanDoAnything:
-      allowAnonymousRead: true
-  securityRealm:
-    local:
-      allowsSignup: false
-      enableCaptcha: false
-      users:
-      - id: "admin"
-        password: "${ADMIN_PASSWORD}"
 security:
   globaljobdslsecurityconfiguration:
     useScriptSecurity: false


### PR DESCRIPTION
With the jenkins auth config in the main jenkins.yaml, it's impossible to override this to use a different authentication method.
Instead, move the auth into a seperate yaml file which can be overwritten/deleted by other deployments to use LDAP/github etc.