### PR TITLE
plugins-extra: add timestamper

### DIFF
--- a/plugins-extra.txt
+++ b/plugins-extra.txt
@@ -1,1 +1,2 @@
 github-oauth
+timestamper


### PR DESCRIPTION
To enable for all pipeline jobs using config-as-code, add this to
the 'unclassified' section of jenkins.yaml:

```
unclassified:
  # requires Timestamper plugin
  timestamperConfig:
    allPipelines: true
    elapsedTimeFormat: "'<b>'HH:mm:ss.S'</b> '"
    systemTimeFormat: "'<b>'HH:mm:ss'</b> '"
```

Signed-off-by: Kevin Hilman <khilman@baylibre.com>