### PR TITLE
Move rootfs jpl files from kernelci-core/jenkins

### DIFF
--- a/jobs.groovy
+++ b/jobs.groovy
@@ -11,6 +11,8 @@ def KCI_BISECTION_EMAIL_RECIPIENTS = System.getenv("KCI_BISECTION_EMAIL_RECIPIEN
 def KCI_BISECTION_TREES_WHITELIST = System.getenv("KCI_BISECTION_TREES_WHITELIST")
 def KCI_BISECTION_LABS_WHITELIST = System.getenv("KCI_BISECTION_LABS_WHITELIST")
 def KCI_MONITOR_CRON = System.getenv("KCI_MONITOR_CRON")
+def KCI_JENKINS_BRANCH = System.getenv("KCI_JENKINS_BRANCH")
+def KCI_JENKINS_URL = System.getenv("KCI_JENKINS_URL")
 
 pipelineJob('kernel-tree-monitor') {
   definition {
@@ -200,13 +202,13 @@ pipelineJob('rootfs-build-trigger') {
       lightweight(true)
       scm {
         git {
-          branch(KCI_CORE_BRANCH)
+          branch(KCI_JENKINS_BRANCH)
           remote {
-            url(KCI_CORE_URL)
+            url(KCI_JENKINS_URL)
           }
         }
       }
-      scriptPath('jenkins/rootfs-trigger.jpl')
+      scriptPath('jobs/rootfs-trigger.jpl')
     }
   }
   configure { project ->
@@ -236,13 +238,13 @@ pipelineJob('rootfs-builder') {
       lightweight(true)
       scm {
         git {
-          branch(KCI_CORE_BRANCH)
+          branch(KCI_JENKINS_BRANCH)
           remote {
-            url(KCI_CORE_URL)
+            url(KCI_JENKINS_URL)
           }
         }
       }
-      scriptPath('jenkins/rootfs-builder.jpl')
+      scriptPath('jobs/rootfs-builder.jpl')
     }
   }
   configure { project ->

--- a/jobs/rootfs-builder.jpl
+++ b/jobs/rootfs-builder.jpl
@@ -1,0 +1,116 @@
+#!/usr/bin/env groovy
+
+/*
+  Copyright (C) 2020 Collabora Limited
+  Author: Lakshmipathi Ganapathi <lakshmipathi.ganapathi@collabora.com>
+
+  This module is free software; you can redistribute it and/or modify it under
+  the terms of the GNU Lesser General Public License as published by the Free
+  Software Foundation; either version 2.1 of the License, or (at your option)
+  any later version.
+
+  This library is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+  details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with this library; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+/* ----------------------------------------------------------------------------
+ * Jenkins parameters
+
+KCI_CORE_URL (https://github.com/kernelci/kernelci-core.git)
+  URL of the kernelci-core repository
+KCI_CORE_BRANCH (master)
+  Name of the branch to use in the kernelci-core repository
+KCI_API_URL (https://api.kernelci.org)
+  URL of the KernelCI backend API
+KCI_TOKEN_ID
+  Identifier of the KernelCI backend API token stored in Jenkins
+DOCKER_BASE
+  Dockerhub base address used for the build images
+ROOTFS_CONFIG
+  Configuration name to build RootFS images
+ROOTFS_ARCH
+  RootFS image architecture
+PIPELINE_VERSION
+  Unique string identifier for the series of rootfs build jobs
+*/
+
+
+@Library('kernelci') _
+import org.kernelci.util.Job
+
+def build(config, arch, pipeline_version, kci_core) {
+    dir(kci_core) {
+        sh(script: """\
+./kci_rootfs \
+build \
+--config ${config} \
+--arch ${arch} \
+--data-path jenkins/debian/debos
+mkdir -p ${pipeline_version}
+mv jenkins/debian/debos/${config}/* ${pipeline_version}
+""")
+    }
+}
+
+def upload(config, pipeline_version, kci_core) {
+    dir(kci_core) {
+        withCredentials([string(credentialsId: params.KCI_TOKEN_ID,
+                                variable: 'API_TOKEN')]) {
+            sh(script: """\
+./kci_rootfs \
+upload \
+--token ${API_TOKEN} \
+--api ${params.KCI_API_URL} \
+--rootfs-dir ${pipeline_version} \
+--upload-path images/rootfs/debian/${config}/${pipeline_version}
+""")
+        }
+    }
+}
+
+node("debos && docker") {
+    def j = new Job()
+    def kci_core = "${env.WORKSPACE}/kernelci-core"
+    def config = "${params.ROOTFS_CONFIG}"
+    def arch = "${params.ROOTFS_ARCH}"
+    def pipeline_version =  "${params.PIPELINE_VERSION}"
+    def docker_image = "${params.DOCKER_BASE}debos"
+
+    print("""\
+    Config:    ${config}
+    CPU arch:  ${arch}
+    Pipeline:  ${pipeline_version}
+    Container: ${docker_image}""")
+
+    if (!config || !arch || !pipeline_version) {
+        print("Invalid parameters")
+        currentBuild.result = 'ABORTED'
+        return
+    }
+
+    j.dockerPullWithRetry(docker_image).inside() {
+        j.cloneKciCore(kci_core, params.KCI_CORE_URL, params.KCI_CORE_BRANCH)
+    }
+
+    j.dockerPullWithRetry(docker_image).
+        inside(" --privileged --device /dev/kvm ") {
+
+        stage("Build") {
+            timeout(time: 4, unit: 'HOURS') {
+	        build(config, arch, pipeline_version, kci_core)
+            }
+        }
+
+        stage("Upload") {
+            timeout(time: 30, unit: 'MINUTES') {
+                upload(config, pipeline_version, kci_core);
+            }
+        }
+    }
+}

--- a/jobs/rootfs-trigger.jpl
+++ b/jobs/rootfs-trigger.jpl
@@ -1,0 +1,135 @@
+#!/usr/bin/env groovy
+
+/*
+  Copyright (C) 2020 Collabora Limited
+  Author: Lakshmipathi Ganapathi <lakshmipathi.ganapathi@collabora.com>
+
+  This module is free software; you can redistribute it and/or modify it under
+  the terms of the GNU Lesser General Public License as published by the Free
+  Software Foundation; either version 2.1 of the License, or (at your option)
+  any later version.
+
+  This library is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+  details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with this library; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+/* ----------------------------------------------------------------------------
+ * Jenkins parameters
+
+KCI_CORE_URL (https://github.com/kernelci/kernelci-core.git)
+  URL of the kernelci-core repository
+KCI_CORE_BRANCH (master)
+  Name of the branch to use in the kernelci-core repository
+DOCKER_BASE
+  Dockerhub base address used for the build images
+ROOTFS_CONFIG
+  Set this to limit the rootfs builds to only one configuration
+ROOTFS_ARCH
+  Set this to limit the rootfs builds to only one architecture
+*/
+
+@Library('kernelci') _
+import org.kernelci.util.Job
+
+
+def listVariants(kci_core, config_list, rootfs_config, rootfs_arch) {
+    def cli_opts = ' '
+
+    if (rootfs_config) {
+        cli_opts += " --config ${rootfs_config}"
+    }
+
+    if (rootfs_arch) {
+        cli_opts += " --arch ${rootfs_arch}"
+    }
+
+    dir(kci_core) {
+        def rootfs_config_list_raw = sh(script: """\
+./kci_rootfs \
+list_variants \
+${cli_opts}
+""", returnStdout: true).trim()
+
+        def rootfs_config_list =  rootfs_config_list_raw.tokenize('\n')
+
+        for (String rootfs_config_raw: rootfs_config_list) {
+            def data = rootfs_config_raw.tokenize(' ')
+            def config = data[0]
+            def arch = data[1]
+            config_list.add([config, arch])
+        }
+    }
+}
+
+
+def buildRootfsStep(job, config ,arch) {
+    def pipeline_version = VersionNumber(
+        versionNumberString: '${BUILD_DATE_FORMATTED,"yyyyMMdd"}.${BUILDS_TODAY_Z}')
+
+    def str_params = [
+        'ROOTFS_CONFIG': config,
+        'ROOTFS_ARCH': arch,
+        'PIPELINE_VERSION':pipeline_version,
+    ]
+    def job_params = []
+
+    def j = new Job()
+    j.addStrParams(job_params, str_params)
+
+    return {
+        def res = build(job: job, parameters: job_params, propagate: false)
+    }
+}
+
+
+node("docker && build-trigger") {
+    def j = new Job()
+    def kci_core = "${env.WORKSPACE}/kernelci-core"
+    def docker_image = "${params.DOCKER_BASE}debos"
+    def configs = []
+
+    print("""\
+    Config:    ${params.ROOTFS_CONFIG}
+    CPU arch:  ${params.ROOTFS_ARCH}
+    Container: ${docker_image}""")
+
+    j.dockerPullWithRetry(docker_image).inside() {
+
+        stage("Init") {
+            timeout(time: 15, unit: 'MINUTES') {
+                j.cloneKciCore(
+                    kci_core, params.KCI_CORE_URL, params.KCI_CORE_BRANCH)
+            }
+        }
+
+        stage("Configs") {
+            listVariants(kci_core, configs, params.ROOTFS_CONFIG,
+                         params.ROOTFS_ARCH)
+        }
+
+        stage("Build") {
+            def builds = [:]
+            def i = 0
+
+            for (item in configs) {
+                def config_name = item[0]
+                def arch = item[1]
+                def step_name = "${i} ${config_name} ${arch}"
+                print(step_name)
+
+                builds[step_name] = buildRootfsStep(
+                    "rootfs-builder", config_name, arch)
+
+                i += 1
+            }
+
+            parallel(builds)
+        }
+    }
+}


### PR DESCRIPTION
Move rootfs-builder.jpl and rootfs-trigger.jpl from
kernelci-core and update jobs.groovy file.

Signed-off-by: Lakshmipathi <lakshmipathi.ganapathi@collabora.com>