### PR TITLE
jobs/build-trigger.jpl: retry getting lab info

### DIFF
--- a/jobs/build-trigger.jpl
+++ b/jobs/build-trigger.jpl
@@ -327,10 +327,12 @@ node("docker && build-trigger") {
                 for (lab in labs_list) {
                     def lab_json = "${labs_info}/${lab}.json"
                     def token = "${lab}-lava-api"
-                    try {
-                        withCredentials([string(credentialsId: token,
-                                                variable: 'SECRET')]) {
-                            sh(script: """\
+                    def retry = 3
+                    while (retry--) {
+                        try {
+                            withCredentials([string(credentialsId: token,
+                                                    variable: 'SECRET')]) {
+                                sh(script: """\
 ./kci_test \
 get_lab_info \
 --lab=${lab} \
@@ -338,10 +340,12 @@ get_lab_info \
 --user=kernel-ci \
 --token=${SECRET} \
 """)
+                            }
+                            labs.add(lab)
+                            retry = 0
+                        } catch (error) {
+                            print("Error with ${lab}: ${error}")
                         }
-                        labs.add(lab)
-                    } catch (error) {
-                        print("Error with ${lab}: ${error}")
                     }
                 }
             }


### PR DESCRIPTION
Due to an intermittent issue with LAVA returning HTTP 502 when
querying the list of available devices, retry getting the lab info to
make it more resilient until the issue is fixed in LAVA.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>