### PR TITLE
build-trigger: make kselftest configs medium

### DIFF
--- a/jobs/build-trigger.jpl
+++ b/jobs/build-trigger.jpl
@@ -233,6 +233,9 @@ def buildKernelStep(job, arch, defconfig, build_env, opts, labs, kci_core) {
     } else if (defconfig.matches("^defconfig.*") && arch == "arm64") {
         node_label = "k8s-medium"
         parallel_builds = ""
+    } else if (defconfig.matches(".*kselftest.config.*")) {
+        node_label = "k8s-medium"
+        parallel_builds = ""
     }
 
     def str_params = [


### PR DESCRIPTION
kselftest builds take a bit longer than other builds, tag them for
"medium" build nodes.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>