### PR TITLE
plugins-extra.txt: drop github-auth

### DIFF
--- a/plugins-extra.txt
+++ b/plugins-extra.txt
@@ -1,2 +1,1 @@
-github-oauth
 timestamper


### PR DESCRIPTION
The github-auth plugin is failing to install, and it's not actually
used.  Drop it from the plugins-extra.txt file.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>