### PR TITLE
Load KCI_API_TOKEN_ID from environment and use it on Kubernetes builders

### DIFF
--- a/jobs.groovy
+++ b/jobs.groovy
@@ -121,6 +121,7 @@ pipelineJob('kernel-build') {
     booleanParam('EMAIL', true, 'Send build results via email')
     stringParam('KCI_API_URL', KCI_API_URL, 'URL of the KernelCI back-end API.')
     stringParam('KCI_TOKEN_ID', 'api-token', 'Identifier of the KernelCI backend API token stored in Jenkins.')
+    stringParam('KCI_STORAGE_URL', KCI_STORAGE_URL, 'URL of the KernelCI storage server.')
     stringParam('KCI_CORE_URL', KCI_CORE_URL, 'URL of the kernelci-core repository.')
     stringParam('KCI_CORE_BRANCH', KCI_CORE_BRANCH, 'Name of the branch to use in the kernelci-core repository.')
     stringParam('PARALLEL_BUILDS', '4', 'Number of kernel builds to run in parallel')

--- a/jobs.groovy
+++ b/jobs.groovy
@@ -2,6 +2,7 @@ def KCI_CORE_BRANCH = System.getenv("KCI_CORE_BRANCH")
 def KCI_CORE_URL = System.getenv("KCI_CORE_URL")
 def KCI_STORAGE_URL = System.getenv("KCI_STORAGE_URL")
 def KCI_API_URL = System.getenv("KCI_API_URL")
+def KCI_API_TOKEN_ID = System.getenv("KCI_API_TOKEN_ID")
 def KCI_DOCKER_BASE = System.getenv("KCI_DOCKER_BASE")
 def KCI_CONFIG_LIST = System.getenv("KCI_CONFIG_LIST")
 def KCI_LABS_LIST = System.getenv("KCI_LABS_LIST")
@@ -36,7 +37,7 @@ pipelineJob('kernel-tree-monitor') {
   }
   parameters {
     stringParam('KCI_API_URL', KCI_API_URL, 'URL of the KernelCI back-end API.')
-    stringParam('KCI_TOKEN_ID', 'api-token', 'Identifier of the KernelCI backend API token stored in Jenkins.')
+    stringParam('KCI_API_TOKEN_ID', KCI_API_TOKEN_ID, 'Identifier of the KernelCI backend API token stored in Jenkins.')
     stringParam('KCI_STORAGE_URL', KCI_STORAGE_URL, 'URL of the KernelCI storage server.')
     stringParam('KCI_CORE_URL', KCI_CORE_URL, 'URL of the kernelci-core repository.')
     stringParam('KCI_CORE_BRANCH', KCI_CORE_BRANCH, 'Name of the branch to use in the kernelci-core repository.')
@@ -74,7 +75,7 @@ pipelineJob('kernel-build-trigger') {
     booleanParam('PUBLISH', true, 'Publish build results via the KernelCI backend API')
     booleanParam('EMAIL', true, 'Send build results via email')
     stringParam('LABS_WHITELIST', KCI_LABS_LIST, 'List of labs to include in the tests, all labs will be tested by default.')
-    stringParam('KCI_TOKEN_ID', 'api-token', 'Identifier of the KernelCI backend API token stored in Jenkins.')
+    stringParam('KCI_API_TOKEN_ID', KCI_API_TOKEN_ID, 'Identifier of the KernelCI backend API token stored in Jenkins.')
     stringParam('KCI_API_URL', KCI_API_URL, 'URL of the KernelCI Backend API')
     stringParam('KCI_STORAGE_URL', KCI_STORAGE_URL, 'URL of the KernelCI storage server.')
     stringParam('KCI_CORE_URL', KCI_CORE_URL, 'URL of the kernelci-core repository.')
@@ -120,7 +121,7 @@ pipelineJob('kernel-build') {
     booleanParam('PUBLISH', true, 'Publish build results via the KernelCI backend API')
     booleanParam('EMAIL', true, 'Send build results via email')
     stringParam('KCI_API_URL', KCI_API_URL, 'URL of the KernelCI back-end API.')
-    stringParam('KCI_TOKEN_ID', 'api-token', 'Identifier of the KernelCI backend API token stored in Jenkins.')
+    stringParam('KCI_API_TOKEN_ID', KCI_API_TOKEN_ID, 'Identifier of the KernelCI backend API token stored in Jenkins.')
     stringParam('KCI_STORAGE_URL', KCI_STORAGE_URL, 'URL of the KernelCI storage server.')
     stringParam('KCI_CORE_URL', KCI_CORE_URL, 'URL of the kernelci-core repository.')
     stringParam('KCI_CORE_BRANCH', KCI_CORE_BRANCH, 'Name of the branch to use in the kernelci-core repository.')
@@ -138,7 +139,7 @@ job('kernel-arch-complete') {
   wrappers {
       preBuildCleanup()
       credentialsBinding {
-          string('EMAIL_AUTH_TOKEN', 'api-token')
+          string('EMAIL_AUTH_TOKEN', KCI_API_TOKEN_ID)
       }
   }
   parameters {
@@ -258,7 +259,7 @@ pipelineJob('rootfs-builder') {
     numToKeep(200)
   }
   parameters {
-    stringParam('KCI_TOKEN_ID', 'api-token', 'Identifier of the KernelCI backend API token stored in Jenkins.')
+    stringParam('KCI_API_TOKEN_ID', KCI_API_TOKEN_ID, 'Identifier of the KernelCI backend API token stored in Jenkins.')
     stringParam('KCI_API_URL', KCI_API_URL, 'URL of the KernelCI Backend API')
     stringParam('KCI_STORAGE_URL', KCI_STORAGE_URL, 'URL of the KernelCI storage server.')
     stringParam('KCI_CORE_URL', KCI_CORE_URL, 'URL of the kernelci-core repository.')
@@ -321,7 +322,7 @@ pipelineJob('lava-bisection') {
     stringParam('TREES_WHITELIST', KCI_BISECTION_TREES_WHITELIST, 'If defined, jobs will abort if the KERNEL_TREE is not on that list.')
 
     stringParam('KCI_API_URL', KCI_API_URL, 'URL of the KernelCI back-end API.')
-    stringParam('KCI_TOKEN_ID', 'api-token', 'Identifier of the KernelCI backend API token stored in Jenkins.')
+    stringParam('KCI_API_TOKEN_ID', KCI_API_TOKEN_ID, 'Identifier of the KernelCI backend API token stored in Jenkins.')
     stringParam('KCI_STORAGE_URL', KCI_STORAGE_URL, 'URL of the KernelCI storage server.')
     stringParam('KCI_CORE_URL', KCI_CORE_URL, 'URL of the kernelci-core repository.')
     stringParam('KCI_CORE_BRANCH', KCI_CORE_BRANCH, 'Name of the branch to use in the kernelci-core repository.')

--- a/jobs/build-trigger.jpl
+++ b/jobs/build-trigger.jpl
@@ -32,7 +32,7 @@ LABS_WHITELIST
   List of labs to include in the tests, all labs will be tested by default.
 KCI_API_URL (https://api.kernelci.org)
   URL of the KernelCI backend API
-KCI_TOKEN_ID
+KCI_API_TOKEN_ID
   Identifier of the KernelCI backend API token stored in Jenkins
 KCI_STORAGE_URL (https://storage.kernelci.org/)
   URL of the KernelCI storage server
@@ -103,7 +103,7 @@ describe \
         opts['describe'] = describe_list[1]
         opts['describe_verbose'] = describe_list[2]
 
-        withCredentials([string(credentialsId: params.KCI_TOKEN_ID,
+        withCredentials([string(credentialsId: params.KCI_API_TOKEN_ID,
                                 variable: 'SECRET')]) {
             sh(script: """\
 ./kci_build \
@@ -249,7 +249,7 @@ def buildKernelStep(job, arch, defconfig, build_env, opts, labs, kci_core) {
         'KCI_CORE_URL': "${params.KCI_CORE_URL}",
         'KCI_CORE_BRANCH': "${params.KCI_CORE_BRANCH}",
         'KCI_API_URL': "${params.KCI_API_URL}",
-        'KCI_TOKEN_ID': "${params.KCI_TOKEN_ID}",
+        'KCI_API_TOKEN_ID': "${params.KCI_API_TOKEN_ID}",
         'KCI_STORAGE_URL': "${params.KCI_STORAGE_URL}",
         'DOCKER_BASE': "${params.DOCKER_BASE}",
     ]

--- a/jobs/build-trigger.jpl
+++ b/jobs/build-trigger.jpl
@@ -250,6 +250,7 @@ def buildKernelStep(job, arch, defconfig, build_env, opts, labs, kci_core) {
         'KCI_CORE_BRANCH': "${params.KCI_CORE_BRANCH}",
         'KCI_API_URL': "${params.KCI_API_URL}",
         'KCI_TOKEN_ID': "${params.KCI_TOKEN_ID}",
+        'KCI_STORAGE_URL': "${params.KCI_STORAGE_URL}",
         'DOCKER_BASE': "${params.DOCKER_BASE}",
     ]
     def job_params = []

--- a/jobs/build.jpl
+++ b/jobs/build.jpl
@@ -46,7 +46,7 @@ EMAIL (boolean)
   Send build results via email
 KCI_API_URL (https://api.kernelci.org)
   URL of the KernelCI backend API
-KCI_TOKEN_ID
+KCI_API_TOKEN_ID
   Identifier of the KernelCI backend API token stored in Jenkins
 KCI_STORAGE_URL (https://storage.kernelci.org/)
   URL of the KernelCI storage server

--- a/jobs/build.jpl
+++ b/jobs/build.jpl
@@ -48,6 +48,8 @@ KCI_API_URL (https://api.kernelci.org)
   URL of the KernelCI backend API
 KCI_TOKEN_ID
   Identifier of the KernelCI backend API token stored in Jenkins
+KCI_STORAGE_URL (https://storage.kernelci.org/)
+  URL of the KernelCI storage server
 KCI_CORE_URL (https://github.com/kernelci/kernelci-core.git)
   URL of the kernelci-core repository
 KCI_CORE_BRANCH (master)
@@ -99,7 +101,7 @@ node("docker" && params.NODE_LABEL) {
 
 	    stage("Build") {
 		timeout(time: 45, unit: 'MINUTES') {
-		    def k8s_job = sh(script:"DOCKER_IMAGE=${build_env_docker_image} ./templates/k8s/gen.py", 
+		    def k8s_job = sh(script:"DOCKER_IMAGE=${build_env_docker_image} ./templates/k8s/gen.py",
 				     returnStdout: true).trim()
 
 		    /* submit */
@@ -116,8 +118,8 @@ node("docker" && params.NODE_LABEL) {
 			upload_path = upload_path_line[1].trim()
 			print("Upload path: ${upload_path}")
 
-			sh(script: "wget -q http://storage.staging.kernelci.org/${upload_path}/bmeta.json")
-			sh(script: "wget -q http://storage.staging.kernelci.org/${upload_path}/dtbs.json")
+			sh(script: "wget -q ${KCI_STORAGE_URL}/${upload_path}/bmeta.json")
+			sh(script: "wget -q ${KCI_STORAGE_URL}/${upload_path}/dtbs.json")
 			archiveArtifacts("*.json")
 		    }
 		}

--- a/jobs/rootfs-builder.jpl
+++ b/jobs/rootfs-builder.jpl
@@ -28,7 +28,7 @@ KCI_CORE_BRANCH (master)
   Name of the branch to use in the kernelci-core repository
 KCI_API_URL (https://api.kernelci.org)
   URL of the KernelCI backend API
-KCI_TOKEN_ID
+KCI_API_TOKEN_ID
   Identifier of the KernelCI backend API token stored in Jenkins
 DOCKER_BASE
   Dockerhub base address used for the build images
@@ -60,7 +60,7 @@ mv jenkins/debian/debos/${config}/* ${pipeline_version}
 
 def upload(config, pipeline_version, kci_core) {
     dir(kci_core) {
-        withCredentials([string(credentialsId: params.KCI_TOKEN_ID,
+        withCredentials([string(credentialsId: params.KCI_API_TOKEN_ID,
                                 variable: 'API_TOKEN')]) {
             sh(script: """\
 ./kci_rootfs \


### PR DESCRIPTION
Rather than having a hard-coded kernelci-backend API token ID, load it from the environement so each instance can have its own value.  Also use it in Kubernetes jobs to load the API token locally.