### PR TITLE
jobs/*.jpl: use --db-token and --lab-token

### DIFF
--- a/jobs/bisect.jpl
+++ b/jobs/bisect.jpl
@@ -268,7 +268,7 @@ install_kernel \
 ./kci_build \
 push_kernel \
 --kdir=${kdir} \
---token=${SECRET} \
+--db-token=${SECRET} \
 --api=${params.KCI_API_URL} \
 """)
         }
@@ -302,7 +302,7 @@ get_lab_info \
 --lab=${params.LAB} \
 --lab-json=${env._LAB_JSON} \
 --user=kernel-ci \
---token=${SECRET} \
+--lab-token=${SECRET} \
 """)
         }
         stash(name: env._LAB_JSON, includes: env._LAB_JSON)
@@ -335,7 +335,7 @@ generate \
 --storage=${params.KCI_STORAGE_URL} \
 --lab=${params.LAB} \
 --user=kernel-ci \
---token=${SECRET} \
+--lab-token=${SECRET} \
 --callback-id=${params.LAVA_CALLBACK} \
 --callback-url=${hook.getURL()} \
 --callback-dataset=results \
@@ -350,7 +350,7 @@ generate \
 submit \
 --lab=${params.LAB} \
 --user=kernel-ci \
---token=${SECRET} \
+--lab-token=${SECRET} \
 --jobs=job.yaml \
 """)
         }

--- a/jobs/build-trigger.jpl
+++ b/jobs/build-trigger.jpl
@@ -111,7 +111,7 @@ update_last_commit \
 --config=${config} \
 --commit=${opts['commit']} \
 --api=${params.KCI_API_URL} \
---token=${SECRET} \
+--db-token=${SECRET} \
 """)
 
             sh(script: """\
@@ -128,7 +128,7 @@ push_tarball \
 --kdir=${kdir} \
 --storage=${params.KCI_STORAGE_URL} \
 --api=${params.KCI_API_URL} \
---token=${SECRET} \
+--db-token=${SECRET} \
 """, returnStdout: true).trim()
         }
     }
@@ -339,7 +339,7 @@ get_lab_info \
 --lab=${lab} \
 --lab-json=${lab_json} \
 --user=kernel-ci \
---token=${SECRET} \
+--lab-token=${SECRET} \
 """)
                             }
                             labs.add(lab)

--- a/jobs/rootfs-builder.jpl
+++ b/jobs/rootfs-builder.jpl
@@ -65,7 +65,7 @@ def upload(config, pipeline_version, kci_core) {
             sh(script: """\
 ./kci_rootfs \
 upload \
---token ${API_TOKEN} \
+--db-token ${API_TOKEN} \
 --api ${params.KCI_API_URL} \
 --rootfs-dir ${pipeline_version} \
 --upload-path images/rootfs/debian/${config}/${pipeline_version}

--- a/jobs/test-runner.jpl
+++ b/jobs/test-runner.jpl
@@ -81,7 +81,7 @@ generate \
 --storage=${params.KCI_STORAGE_URL} \
 --lab=${lab} \
 --user=kernel-ci \
---token=${SECRET} \
+--lab-token=${SECRET} \
 --output=${jobs_dir} \
 --callback-id=${params.CALLBACK_ID} \
 --callback-url=${params.CALLBACK_URL} \
@@ -101,7 +101,7 @@ def submitJobs(kci_core, lab, jobs_dir)
 submit \
 --lab=${lab} \
 --user=kernel-ci \
---token=${SECRET} \
+--lab-token=${SECRET} \
 --jobs=${jobs_dir}/* \
 """)
         }


### PR DESCRIPTION
Use the new --db-token and --lab-token command line arguments which
replace the ambiguous --token argument.  This relies on the latest
kernelci-core version to be installed with the renamed arguments.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>

Depends on https://github.com/kernelci/kernelci-core/pull/457