### PR TITLE
jobs/build-trigger.jpl: skip empty test-runner jobs

### DIFF
--- a/jobs/build-trigger.jpl
+++ b/jobs/build-trigger.jpl
@@ -220,6 +220,7 @@ def getLabsWithTests(build_job_name, number, labs, kci_core) {
             def lab_json = "${labs_info}/${lab}.json"
 
             def raw_jobs = sh(script: """\
+#!/bin/sh -e
 ./kci_test \
 list_jobs \
 --lab=${lab} \

--- a/jobs/build-trigger.jpl
+++ b/jobs/build-trigger.jpl
@@ -202,6 +202,42 @@ tree_branch \
     }
 }
 
+def getLabsWithTests(build_job_name, number, labs, kci_core) {
+    def artifacts = "${env.WORKSPACE}/artifacts-${build_job_name}-${number}"
+    def lab_list = []
+
+    dir(artifacts) {
+        copyArtifacts(
+            projectName: build_job_name,
+            selector: specific("${number}")
+        )
+    }
+
+    dir(kci_core) {
+        def labs_info = "${env.WORKSPACE}/labs"
+
+        for (lab in labs) {
+            def lab_json = "${labs_info}/${lab}.json"
+
+            def raw_jobs = sh(script: """\
+./kci_test \
+list_jobs \
+--lab=${lab} \
+--lab-json=${lab_json} \
+--bmeta-json=${artifacts}/bmeta.json \
+--dtbs-json=${artifacts}/dtbs.json \
+""", returnStdout: true).trim()
+
+            if (raw_jobs)
+                lab_list.push(lab)
+        }
+    }
+
+    sh(script: "rm -rf ${artifacts}")
+
+    return lab_list
+}
+
 def scheduleTests(build_job_name, build_job_number, labs, kci_core) {
     dir(kci_core) {
         def labs_str = ""
@@ -261,8 +297,12 @@ def buildKernelStep(job, arch, defconfig, build_env, opts, labs, kci_core) {
     return {
         def res = build(job: job, parameters: job_params, propagate: false)
         print("${res.number}: ${arch} ${defconfig} ${build_env} ${res.result}")
-        if (res.result == "SUCCESS")
-            scheduleTests(job, res.number, labs, kci_core)
+        if (res.result == "SUCCESS") {
+            def test_labs = getLabsWithTests(job, res.number, labs, kci_core)
+            if (test_labs) {
+                scheduleTests(job, res.number, test_labs, kci_core)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Get the list of test jobs to run for each kernel build before starting
a test-runner job.  This is to avoid unnecessary overhead in Jenkins,
with many test-runner jobs started only to find out that no tests are
to be run.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>