### PR TITLE
T23120 jobs/*.jpl: use new --{build,lab}-config arguments

### DIFF
--- a/jobs/bisect.jpl
+++ b/jobs/bisect.jpl
@@ -299,7 +299,7 @@ def fetchLabInfo(kci_core) {
             sh(script: """\
 ./kci_test \
 get_lab_info \
---lab=${params.LAB} \
+--lab-config=${params.LAB} \
 --lab-json=${env._LAB_JSON} \
 --user=kernel-ci \
 --lab-token=${SECRET} \
@@ -333,7 +333,7 @@ generate \
 --dtbs-json=${env._DTBS_JSON} \
 --lab-json=${env._LAB_JSON} \
 --storage=${params.KCI_STORAGE_URL} \
---lab=${params.LAB} \
+--lab-config=${params.LAB} \
 --user=kernel-ci \
 --lab-token=${SECRET} \
 --callback-id=${params.LAVA_CALLBACK} \
@@ -348,7 +348,7 @@ generate \
             sh(script: """ \
 ./kci_test \
 submit \
---lab=${params.LAB} \
+--lab-config=${params.LAB} \
 --user=kernel-ci \
 --lab-token=${SECRET} \
 --jobs=job.yaml \
@@ -514,7 +514,7 @@ PYTHON_EGG_CACHE=${egg_cache} \
 ./push-bisection-results.py \
 --token=${SECRET} \
 --api=${params.KCI_API_URL} \
---lab=${params.LAB} \
+--lab-config=${params.LAB} \
 --arch=${params.ARCH} \
 --defconfig=${params.DEFCONFIG} \
 --build-environment=${params.BUILD_ENVIRONMENT} \

--- a/jobs/build-trigger.jpl
+++ b/jobs/build-trigger.jpl
@@ -57,7 +57,7 @@ def configAlreadyBuilt(config, kci_core) {
         script: """\
 ./kci_build \
 check_new_commit \
---config=${config} \
+--build-config=${config} \
 --storage=${params.KCI_STORAGE_URL} \
 """, returnStdout: true).trim()
     }
@@ -70,7 +70,7 @@ def pushTarball(config, kci_core, mirror, kdir, opts) {
         sh(script: """\
 ./kci_build \
 update_mirror \
---config=${config} \
+--build-config=${config} \
 --mirror=${mirror} \
 """)
 
@@ -79,7 +79,7 @@ update_mirror \
                 sh(script: """\
 ./kci_build \
 update_repo \
---config=${config} \
+--build-config=${config} \
 --kdir=${kdir} \
 --mirror=${mirror} \
 """)
@@ -95,7 +95,7 @@ update_repo \
         def describe_raw = sh(script: """\
 ./kci_build \
 describe \
---config=${config} \
+--build-config=${config} \
 --kdir=${kdir} \
 """, returnStdout: true).trim()
         def describe_list = describe_raw.tokenize('\n')
@@ -108,7 +108,7 @@ describe \
             sh(script: """\
 ./kci_build \
 update_last_commit \
---config=${config} \
+--build-config=${config} \
 --commit=${opts['commit']} \
 --api=${params.KCI_API_URL} \
 --db-token=${SECRET} \
@@ -117,14 +117,14 @@ update_last_commit \
             sh(script: """\
 ./kci_build \
 generate_fragments \
---config=${config} \
+--build-config=${config} \
 --kdir=${kdir} \
 """)
 
             opts['tarball_url'] = sh(script: """\
 ./kci_build \
 push_tarball \
---config=${config} \
+--build-config=${config} \
 --kdir=${kdir} \
 --storage=${params.KCI_STORAGE_URL} \
 --api=${params.KCI_API_URL} \
@@ -139,7 +139,7 @@ def listConfigs(config, kci_core, kdir, config_list) {
         def kernel_config_list_raw = sh(script: """\
 ./kci_build \
 list_kernel_configs \
---config=${config} \
+--build-config=${config} \
 --kdir=${kdir} \
 """, returnStdout: true).trim()
         def kernel_config_list = kernel_config_list_raw.tokenize('\n')
@@ -162,7 +162,7 @@ def listArchitectures(kci_core, config) {
             script: """\
 ./kci_build \
 list_variants \
---config=${config} \
+--build-config=${config} \
 """, returnStdout: true).trim()
         def variants = raw_variants.tokenize('\n')
 
@@ -171,7 +171,7 @@ list_variants \
                 script: """\
 ./kci_build \
 arch_list \
---config=${config} \
+--build-config=${config} \
 --variant=${variant} \
 """, returnStdout: true).trim()
             def variant_arch_list = raw_variant_arch_list.tokenize('\n')
@@ -193,7 +193,7 @@ def addBuildOpts(config, kci_core, opts) {
             script: """\
 ./kci_build \
 tree_branch \
---config=${config} \
+--build-config=${config} \
 """, returnStdout: true).trim()
         def opt_list = opts_raw.tokenize('\n')
         opts['tree'] = opt_list[0]
@@ -223,7 +223,7 @@ def getLabsWithTests(build_job_name, number, labs, kci_core) {
 #!/bin/sh -e
 ./kci_test \
 list_jobs \
---lab=${lab} \
+--lab-config=${lab} \
 --lab-json=${lab_json} \
 --bmeta-json=${artifacts}/bmeta.json \
 --dtbs-json=${artifacts}/dtbs.json \
@@ -377,7 +377,7 @@ node("docker && build-trigger") {
                                 sh(script: """\
 ./kci_test \
 get_lab_info \
---lab=${lab} \
+--lab-config=${lab} \
 --lab-json=${lab_json} \
 --user=kernel-ci \
 --lab-token=${SECRET} \

--- a/jobs/monitor.jpl
+++ b/jobs/monitor.jpl
@@ -51,7 +51,7 @@ def checkConfig(config, kci_core, trees_dir) {
 ${kci_core}/kci_build \
 --yaml-configs=${kci_core}/build-configs.yaml \
 check_new_commit \
---config=${config} \
+--build-config=${config} \
 --storage=${params.KCI_STORAGE_URL} \
 """, returnStdout: true).trim()
 

--- a/jobs/rootfs-builder.jpl
+++ b/jobs/rootfs-builder.jpl
@@ -49,7 +49,7 @@ def build(config, arch, pipeline_version, kci_core) {
         sh(script: """\
 ./kci_rootfs \
 build \
---config ${config} \
+--rootfs-config ${config} \
 --arch ${arch} \
 --data-path jenkins/debian/debos
 mkdir -p ${pipeline_version}

--- a/jobs/rootfs-trigger.jpl
+++ b/jobs/rootfs-trigger.jpl
@@ -42,7 +42,7 @@ def listVariants(kci_core, config_list, rootfs_config, rootfs_arch) {
     def cli_opts = ' '
 
     if (rootfs_config) {
-        cli_opts += " --config ${rootfs_config}"
+        cli_opts += " --rootfs-config ${rootfs_config}"
     }
 
     if (rootfs_arch) {

--- a/jobs/test-runner.jpl
+++ b/jobs/test-runner.jpl
@@ -79,7 +79,7 @@ generate \
 --dtbs-json=${artifacts}/dtbs.json \
 --lab-json=${artifacts}/${lab}.json \
 --storage=${params.KCI_STORAGE_URL} \
---lab=${lab} \
+--lab-config=${lab} \
 --user=kernel-ci \
 --lab-token=${SECRET} \
 --output=${jobs_dir} \
@@ -99,7 +99,7 @@ def submitJobs(kci_core, lab, jobs_dir)
             sh(script: """\
 ./kci_test \
 submit \
---lab=${lab} \
+--lab-config=${lab} \
 --user=kernel-ci \
 --lab-token=${SECRET} \
 --jobs=${jobs_dir}/* \


### PR DESCRIPTION
Use new command-line arguments --build-config and --lab-config which
replace the generic --config one.

Depends on https://github.com/kernelci/kernelci-core/pull/465