### PR TITLE
restart-compose.sh: first try a clean container shutdown

### DIFF
--- a/restart-compose.sh
+++ b/restart-compose.sh
@@ -2,21 +2,21 @@
 
 set -e
 
+echo "Shutting down Jenkins container..."
+docker-compose down
+
 jenkins_container=$(docker ps | grep kernelci-jenkins_jenkins) || echo -n ''
 if [ -n "$jenkins_container" ]; then
   echo "$jenkins_container"
   container_id=$(echo "$jenkins_container" | cut -c-12)
   echo "Stopping Jenkins container: $container_id..."
   docker stop "$container_id"
-else
-  echo "Jenkins container is not running."
 fi
 
 echo "Updating Jenkins image..."
 docker pull jenkins/jenkins
 
 echo "Starting Jenkins container..."
-
 docker-compose up --build -d
 
 echo "Done."


### PR DESCRIPTION
First run "docker-compose down" to try a clean shutdown of the Jenkins
container.  If for some reason the container is still there after
that, run "docker stop" command like before to ensure it's stopped.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>