### PR TITLE
jobs/bisect.jpl: fix logic for multiple runs

### DIFF
--- a/jobs/bisect.jpl
+++ b/jobs/bisect.jpl
@@ -426,7 +426,7 @@ def runTest(describe, expected=0, runs=0) {
     if (!runs)
         runs = params.TEST_RUNS.toInteger()
 
-    def status = null
+    def status = 0
 
     for (int i = 1; i <= runs; i++) {
         echo "Run ${i} / ${runs}"
@@ -444,7 +444,7 @@ def runTest(describe, expected=0, runs=0) {
                 break
         }
 
-        if (status != expected)
+        if (status)
             break
     }
 


### PR DESCRIPTION
When doing multiple runs, assume that a "pass" requires all the runs
to pass and "fail" at least one to fail.  This helps with checking bad
revisions for intermittent issues, rather than assuming that bad
revisions are consistently failing.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>