### PR TITLE
T23121 Handle Jenkins exceptions

### DIFF
--- a/jobs/build-trigger.jpl
+++ b/jobs/build-trigger.jpl
@@ -337,6 +337,7 @@ node("docker && build-trigger") {
     def docker_image = "${params.DOCKER_BASE}build-base"
     def opts = [:]
     def configs = []
+    def buildStatus = null
 
     print("""\
     Config:    ${params.BUILD_CONFIG}
@@ -437,11 +438,19 @@ get_lab_info \
                 i += 1
             }
 
-            parallel(builds)
+            try {
+                parallel(builds)
+            } catch (err) {
+                print("Builds failed: ${err}")
+                buildStatus = "FAILURE"
+            }
         }
 
         stage("Complete") {
             buildsComplete("kernel-arch-complete", opts)
         }
+
+        if (buildStatus)
+            currentBuild.result = buildStatus;
     }
 }

--- a/jobs/monitor.jpl
+++ b/jobs/monitor.jpl
@@ -46,14 +46,30 @@ DOCKER_BASE (kernelci/)
 import org.kernelci.util.Job
 
 def checkConfig(config, kci_core, trees_dir) {
-    def commit = sh(
+    def retry = 3
+    def commit = null
+
+    while (retry--) {
+        try {
+            commit = sh(
         script: """
 ${kci_core}/kci_build \
 --yaml-configs=${kci_core}/build-configs.yaml \
 check_new_commit \
 --build-config=${config} \
 --storage=${params.KCI_STORAGE_URL} \
-""", returnStdout: true).trim()
+""", returnStdout: true)
+            retry = 0
+        } catch (error) {
+
+            if (retry) {
+                print("Failed to check ${config}, retyring: ${error}")
+                sleep(1)
+            } else {
+                print("ERROR: All attempts failed with ${config}")
+            }
+        }
+    }
 
     if (!commit) {
         print("${config}: no new commit")


### PR DESCRIPTION
Fix issues with Jenkins exceptions, to retry when checking branches in the monitor job and to still send email reports when some error occurs in build-trigger.