### PR TITLE
update kci_build build_kernel output

### DIFF
--- a/jobs/bisect.jpl
+++ b/jobs/bisect.jpl
@@ -249,7 +249,7 @@ build_kernel \
 --defconfig=${expanded_defconfig} \
 --arch=${params.ARCH} \
 --build-env=${params.BUILD_ENVIRONMENT} \
---output=${output} \
+--output=${kdir} \
 """)
 
         sh(script: """\


### PR DESCRIPTION
Some kselftests look for header files in root linux directory,nit updates jenkins jobs to always build and put output in kernel directory.

Signed-off-by: Alexandra Pereira <alexandra.pereira@collabora.com>