### PR TITLE
jobs/bisect.jpl: retry "kci_test get_lab_info" up to 3 times

### DIFF
--- a/jobs/bisect.jpl
+++ b/jobs/bisect.jpl
@@ -294,8 +294,12 @@ def buildRevision(kdir, kci_core, git_rev, name) {
 def fetchLabInfo(kci_core) {
     dir(kci_core) {
         def token = "${params.LAB}-lava-api"
+        def retry = 3
 
-        withCredentials([string(credentialsId: token, variable: 'SECRET')]) {
+        while (retry--) {
+            try {
+                withCredentials([string(credentialsId: token,
+                                        variable: 'SECRET')]) {
             sh(script: """\
 ./kci_test \
 get_lab_info \
@@ -304,6 +308,14 @@ get_lab_info \
 --user=kernel-ci \
 --lab-token=${SECRET} \
 """)
+                    retry = 0
+                }
+            } catch (error) {
+                if (retry)
+                    print("Error with ${lab}: ${error}, retrying...")
+                else
+                    throw error
+            }
         }
         stash(name: env._LAB_JSON, includes: env._LAB_JSON)
     }


### PR DESCRIPTION
There are some known issues with some LAVA labs when a timeout on the
server can cause an occasional HTTP 502 error.  To make the job more
resilient, retry up to 3 times when querying the lab info (i.e. the
list of device types).

This is similar to what is done in build-trigger.jpl, except that for
bisect.jpl the job needs to be aborted.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>