### PR TITLE
jobs/rootfs-builder.jpl: update --data-path to config/rootfs/debos

### DIFF
--- a/jobs/rootfs-builder.jpl
+++ b/jobs/rootfs-builder.jpl
@@ -51,9 +51,9 @@ def build(config, arch, pipeline_version, kci_core) {
 build \
 --rootfs-config ${config} \
 --arch ${arch} \
---data-path jenkins/debian/debos
+--data-path config/rootfs/debos
 mkdir -p ${pipeline_version}
-mv jenkins/debian/debos/${config}/* ${pipeline_version}
+mv config/rootfs/debos/${config}/* ${pipeline_version}
 """)
     }
 }


### PR DESCRIPTION
The rootfs config files are being moved to config/rootfs, so update
the --data-path value accordingly.

Ideally, this should be config/rootfs as the "debos" part can be
deduced from the YAML configuration, but it would require a few more
changes to clean this up.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>