### PR TITLE
jobs/build.jpl: add steps.json and artifacts.json to artifacts

### DIFF
--- a/jobs/build-trigger.jpl
+++ b/jobs/build-trigger.jpl
@@ -225,8 +225,7 @@ def getLabsWithTests(build_job_name, number, labs, kci_core) {
 list_jobs \
 --lab-config=${lab} \
 --lab-json=${lab_json} \
---bmeta-json=${artifacts}/bmeta.json \
---dtbs-json=${artifacts}/dtbs.json \
+--install-path=${artifacts} \
 """, returnStdout: true).trim()
 
             if (raw_jobs)

--- a/jobs/build.jpl
+++ b/jobs/build.jpl
@@ -119,7 +119,8 @@ node("docker" && params.NODE_LABEL) {
 			print("Upload path: ${upload_path}")
 
 			sh(script: "wget -q ${KCI_STORAGE_URL}/${upload_path}/bmeta.json")
-			sh(script: "wget -q ${KCI_STORAGE_URL}/${upload_path}/dtbs.json")
+			sh(script: "wget -q ${KCI_STORAGE_URL}/${upload_path}/steps.json")
+			sh(script: "wget -q ${KCI_STORAGE_URL}/${upload_path}/artifacts.json")
 			archiveArtifacts("*.json")
 		    }
 		}

--- a/jobs/test-runner.jpl
+++ b/jobs/test-runner.jpl
@@ -75,8 +75,7 @@ def generateJobs(kci_core, lab, artifacts, jobs_dir)
             sh(script: """\
 ./kci_test \
 generate \
---bmeta-json=${artifacts}/bmeta.json \
---dtbs-json=${artifacts}/dtbs.json \
+--install-path=${artifacts} \
 --lab-json=${artifacts}/${lab}.json \
 --storage=${params.KCI_STORAGE_URL} \
 --lab-config=${lab} \


### PR DESCRIPTION
Save the new meta-data JSON files with bmeta, steps and artifacts.  Update the calls to kci_test with the command line changes related to the new meta-data.