### PR TITLE
jobs/build-trigger.jpl: fix kselftest config regex

### DIFF
--- a/jobs/build-trigger.jpl
+++ b/jobs/build-trigger.jpl
@@ -270,7 +270,7 @@ def buildKernelStep(job, arch, defconfig, build_env, opts, labs, kci_core) {
     } else if (defconfig.matches("^defconfig.*") && arch == "arm64") {
         node_label = "k8s-medium"
         parallel_builds = ""
-    } else if (defconfig.matches(".*kselftest.config.*")) {
+    } else if (defconfig.matches(".*kselftest.*")) {
         node_label = "k8s-medium"
         parallel_builds = ""
     }


### PR DESCRIPTION
Fix the regular expression when looking for kselftest jobs to schedule
them on medium builders.  The builds parameters now take the
"non-expanded" version of the defconfig, e.g. defconfig+kselftest
rather than the actual config fragment file name kernelci.config.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>