### PR TITLE
jobs/build-trigger.jpl: check new revision before lab info

### DIFF
--- a/jobs/build-trigger.jpl
+++ b/jobs/build-trigger.jpl
@@ -350,7 +350,17 @@ node("docker && build-trigger") {
                 j.cloneKciCore(
                     kci_core, params.KCI_CORE_URL, params.KCI_CORE_BRANCH)
             }
+        }
 
+        if (params.ALLOW_REBUILD != true) {
+            if (configAlreadyBuilt(params.BUILD_CONFIG, kci_core)) {
+                print("Revision already built, aborting")
+                currentBuild.result = 'ABORTED'
+                return
+            }
+        }
+
+        stage("Labs") {
             sh(script: "rm -rf ${labs_info}; mkdir -p ${labs_info}")
 
             dir(kci_core) {
@@ -397,14 +407,6 @@ get_lab_info \
 
             dir(labs_info) {
                 archiveArtifacts("*.json")
-            }
-        }
-
-        if (params.ALLOW_REBUILD != true) {
-            if (configAlreadyBuilt(params.BUILD_CONFIG, kci_core)) {
-                print("Revision already built, aborting")
-                currentBuild.result = 'ABORTED'
-                return
             }
         }
 


### PR DESCRIPTION
Check whether the current HEAD of the branch to build has already been
built before getting the lab-specific info.  Getting all the labs'
info can take a while and it's not necessary to do this before
checking the revision.  So this should speed things up when the queue
of trigger jobs gets congested.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>