### PR TITLE
rootfs: Create a baseline buildroot rootfs image

### DIFF
--- a/jobs.groovy
+++ b/jobs.groovy
@@ -239,7 +239,6 @@ pipelineJob('rootfs-build-trigger') {
     stringParam('DOCKER_BASE', KCI_DOCKER_BASE, 'Dockerhub base address used for the rootfs build images.')
     stringParam('ROOTFS_CONFIG','','Name of the rootfs configuration, all rootfs will be built by default.')
     stringParam('ROOTFS_ARCH','','Name of the rootfs arch config, all given arch will be built by default.')
-    stringParam('ROOTFS_TYPE','debos','Name of the rootfs type which can be debos or buildroot.')
   }
 }
 

--- a/jobs/rootfs-builder.jpl
+++ b/jobs/rootfs-builder.jpl
@@ -44,7 +44,22 @@ PIPELINE_VERSION
 @Library('kernelci') _
 import org.kernelci.util.Job
 
-def build(config, arch, pipeline_version, kci_core) {
+def build_buildroot(config, arch, pipeline_version, kci_core) {
+    dir(kci_core) {
+        sh(script: """\
+git clone https://github.com/kernelci/buildroot
+./kci_rootfs \
+build \
+--rootfs-config ${config} \
+--arch ${arch} \
+--data-path buildroot
+mkdir -p ${pipeline_version}
+mv buildroot/output/images/* ${pipeline_version}
+""")
+    }
+}
+
+def build_debos(config, arch, pipeline_version, kci_core) {
     dir(kci_core) {
         sh(script: """\
 ./kci_rootfs \
@@ -80,7 +95,14 @@ node("debos && docker") {
     def config = "${params.ROOTFS_CONFIG}"
     def arch = "${params.ROOTFS_ARCH}"
     def pipeline_version =  "${params.PIPELINE_VERSION}"
-    def docker_image = "${params.DOCKER_BASE}debos"
+    def docker_image = " "
+    def rootfs_type = "${params.ROOTFS_TYPE}"
+
+    if (rootfs_type == "buildroot") {
+        docker_image = "${params.DOCKER_BASE}buildroot"
+    } else if (rootfs_type == "debos") {
+        docker_image = "${params.DOCKER_BASE}debos"
+    }
 
     print("""\
     Config:    ${config}
@@ -101,11 +123,19 @@ node("debos && docker") {
     j.dockerPullWithRetry(docker_image).
         inside(" --privileged --device /dev/kvm ") {
 
+    if (rootfs_type == "buildroot") {
         stage("Build") {
             timeout(time: 8, unit: 'HOURS') {
-	        build(config, arch, pipeline_version, kci_core)
+	        build_buildroot(config, arch, pipeline_version, kci_core)
             }
         }
+    } else if (rootfs_type == "debos") {
+        stage("Build") {
+            timeout(time: 8, unit: 'HOURS') {
+	        build_debos(config, arch, pipeline_version, kci_core)
+            }
+        }
+     }
 
         stage("Upload") {
             timeout(time: 30, unit: 'MINUTES') {

--- a/jobs/rootfs-builder.jpl
+++ b/jobs/rootfs-builder.jpl
@@ -53,8 +53,8 @@ build \
 --rootfs-config ${config} \
 --arch ${arch} \
 --data-path buildroot
-mkdir -p ${pipeline_version}
-mv buildroot/output/images/* ${pipeline_version}
+mkdir -p ${pipeline_version}/${arch}
+mv buildroot/output/images/* ${pipeline_version}/${arch}
 """)
     }
 }
@@ -73,7 +73,14 @@ mv config/rootfs/debos/${config}/* ${pipeline_version}
     }
 }
 
-def upload(config, pipeline_version, kci_core) {
+def upload(config, pipeline_version, kci_core, rootfs_type, arch) {
+    rootfs_upload_path = "images/rootfs/debian/${config}/${pipeline_version}"
+    print("\n Uploading rootfs_type: ${rootfs_type}")
+
+    if (rootfs_type == "buildroot") {
+       rootfs_upload_path = "images/rootfs/buildroot/${config}/${pipeline_version}"
+    }
+
     dir(kci_core) {
         withCredentials([string(credentialsId: params.KCI_API_TOKEN_ID,
                                 variable: 'API_TOKEN')]) {
@@ -83,7 +90,7 @@ upload \
 --db-token ${API_TOKEN} \
 --api ${params.KCI_API_URL} \
 --rootfs-dir ${pipeline_version} \
---upload-path images/rootfs/debian/${config}/${pipeline_version}
+--upload-path ${rootfs_upload_path}
 """)
         }
     }
@@ -139,7 +146,7 @@ node("debos && docker") {
 
         stage("Upload") {
             timeout(time: 30, unit: 'MINUTES') {
-                upload(config, pipeline_version, kci_core);
+                upload(config, pipeline_version, kci_core, rootfs_type, arch);
             }
         }
     }

--- a/jobs/rootfs-trigger.jpl
+++ b/jobs/rootfs-trigger.jpl
@@ -37,6 +37,24 @@ ROOTFS_ARCH
 @Library('kernelci') _
 import org.kernelci.util.Job
 
+def listBuildrootConfigs(kci_core, buildroot_config_list) {
+    dir(kci_core) {
+        def rootfs_type_list_raw = sh(script: """\
+./kci_rootfs \
+list_configs \
+--rootfs-type buildroot
+""", returnStdout: true).trim()
+
+        def rootfs_type_list =  rootfs_type_list_raw.tokenize('\n')
+
+        for (String rootfs_type_raw: rootfs_type_list) {
+            def data = rootfs_type_raw.tokenize(' ')
+            def config = data[0]
+            buildroot_config_list.add(config)
+        }
+    }
+}
+
 
 def listVariants(kci_core, config_list, rootfs_config, rootfs_arch) {
     def cli_opts = ' '
@@ -94,9 +112,9 @@ def buildRootfsStep(job, config ,arch, rootfs_type) {
 node("docker && build-trigger") {
     def j = new Job()
     def kci_core = "${env.WORKSPACE}/kernelci-core"
-    def docker_image = "${params.DOCKER_BASE}debos"
+    def docker_image = "${params.DOCKER_BASE}build-base"
     def configs = []
-    def rootfs_type = "${params.ROOTFS_TYPE}"
+    def buildroot_configs = []
 
     print("""\
     Config:    ${params.ROOTFS_CONFIG}
@@ -117,6 +135,11 @@ node("docker && build-trigger") {
                          params.ROOTFS_ARCH)
         }
 
+        stage("BuildRootConfigs") {
+            listBuildrootConfigs(kci_core, buildroot_configs)
+            print(buildroot_configs)
+        }
+
         stage("Build") {
             def builds = [:]
             def i = 0
@@ -124,7 +147,12 @@ node("docker && build-trigger") {
             for (item in configs) {
                 def config_name = item[0]
                 def arch = item[1]
-                def step_name = "${i} ${config_name} ${arch}"
+                def rootfs_type = "debos"
+
+                if (config_name in buildroot_configs) {
+                   rootfs_type = "buildroot"
+	        }
+                def step_name = "${i} ${config_name} ${arch} ${rootfs_type}"
                 print(step_name)
 
                 builds[step_name] = buildRootfsStep(

--- a/jobs/rootfs-trigger.jpl
+++ b/jobs/rootfs-trigger.jpl
@@ -68,13 +68,14 @@ ${cli_opts}
 }
 
 
-def buildRootfsStep(job, config ,arch) {
+def buildRootfsStep(job, config ,arch, rootfs_type) {
     def pipeline_version = VersionNumber(
         versionNumberString: '${BUILD_DATE_FORMATTED,"yyyyMMdd"}.${BUILDS_TODAY_Z}')
 
     def str_params = [
         'ROOTFS_CONFIG': config,
         'ROOTFS_ARCH': arch,
+        'ROOTFS_TYPE' : rootfs_type,
         'PIPELINE_VERSION':pipeline_version,
         'KCI_CORE_URL': "${params.KCI_CORE_URL}",
         'KCI_CORE_BRANCH': "${params.KCI_CORE_BRANCH}",
@@ -95,6 +96,7 @@ node("docker && build-trigger") {
     def kci_core = "${env.WORKSPACE}/kernelci-core"
     def docker_image = "${params.DOCKER_BASE}debos"
     def configs = []
+    def rootfs_type = "${params.ROOTFS_TYPE}"
 
     print("""\
     Config:    ${params.ROOTFS_CONFIG}
@@ -126,7 +128,7 @@ node("docker && build-trigger") {
                 print(step_name)
 
                 builds[step_name] = buildRootfsStep(
-                    "rootfs-builder", config_name, arch)
+                    "rootfs-builder", config_name, arch, rootfs_type)
 
                 i += 1
             }


### PR DESCRIPTION
Add buildroot support to rootfs-builder and rootfs-trigger jobs.

Depends on #63