### PR TITLE
rootfs jobs: Convert freestyle rootfs job into pipeline jobs

### DIFF
--- a/jobs/rootfs-builder.jenkinsfile
+++ b/jobs/rootfs-builder.jenkinsfile
@@ -1,0 +1,137 @@
+#!/usr/bin/env groovy
+
+kci_core_url = "${env.KCI_CORE_URL}"
+kci_core_branch = "${env.KCI_CORE_BRANCH}"
+rootfs_arch = "${params.ROOTFS_ARCH}"
+rootfs_config = "${params.ROOTFS_CONFIG}"
+rootfs_type = "${params.ROOTFS_TYPE}"
+docker_image = " "
+
+def configs = []
+
+println "------------------------------------------------------------------------------------"
+println "Config: ${params.ROOTFS_CONFIG} CPU arch: ${params.ROOTFS_ARCH} Container: ${docker_image}"
+println "------------------------------------------------------------------------------------"
+
+pipeline {
+
+  options {
+    timestamps()
+  }
+
+  agent {
+    label 'debos && docker'
+  }
+
+ environment {
+    pipeline_version = VersionNumber(versionNumberString: '${BUILD_DATE_FORMATTED,"yyyyMMdd"}.${BUILDS_TODAY_Z}')
+  }
+
+
+  stages {
+    stage('Init') {
+        steps {
+            git branch: '${kci_core_branch}', url: '${kci_core_url}'
+            script {  
+		     if (!rootfs_config || !rootfs_arch || !pipeline_version) {
+		              print("Invalid parameters")
+		              currentBuild.result = 'ABORTED'
+		              return
+		          }
+	              if ("${rootfs_type}" == "buildroot") {
+        	          docker_image = "${params.DOCKER_BASE}buildroot"
+	              } else if ("${rootfs_type}" == "debos") {
+        	          docker_image = "${params.DOCKER_BASE}debos"
+              		}
+            }
+            }
+    }
+
+    stage("Build") {
+        agent {
+            docker {
+            args ' --privileged  --device=/dev/kvm'
+            image "${docker_image}"
+            reuseNode true
+            }
+        }
+        steps {
+                script {
+                    sh " echo ${kci_core_url} ${kci_core_branch} ${rootfs_arch} ${WORKSPACE} "
+                    if (rootfs_type == "buildroot") {
+			        timeout(time: 8, unit: 'HOURS') {
+                  	        build_buildroot(rootfs_config, rootfs_arch, pipeline_version, ".")
+                    	      }
+            	    } else {
+	                          timeout(time: 8, unit: 'HOURS') {
+        	                  build_debos(rootfs_config, rootfs_arch, pipeline_version, ".")
+      	 	                  }
+            	    }
+                }
+            }
+    }
+
+     stage("Upload") {
+         steps {
+              script {
+                timeout(time: 30, unit: 'MINUTES') {
+                upload(rootfs_config, pipeline_version, ".");
+                }
+              }
+         }
+        } 
+    }
+
+  post {
+    cleanup {
+      deleteDir()
+    }
+  }
+}
+
+def build_buildroot(config, arch, pipeline_version, kci_core) {
+    dir(kci_core) {
+        sh(script: """\
+git clone https://github.com/kernelci/buildroot
+./kci_rootfs \
+build \
+--rootfs-config ${config} \
+--arch ${arch} \
+--data-path buildroot
+mkdir -p ${pipeline_version}
+mv buildroot/output/images/* ${pipeline_version}
+""")
+    }
+}
+
+def build_debos(config, arch, pipeline_version, kci_core) {
+    dir(kci_core) {
+        sh(script: """\
+pwd
+ls -l 
+./kci_rootfs \
+build \
+--rootfs-config ${config} \
+--arch ${arch} \
+--data-path config/rootfs/debos
+mkdir -p ${pipeline_version}
+mv config/rootfs/debos/${config}/* ${pipeline_version}
+""")
+    }
+}
+
+def upload(config, pipeline_version, kci_core) {
+    dir(kci_core) {
+        withCredentials([string(credentialsId: params.KCI_API_TOKEN_ID,
+                                variable: 'API_TOKEN')]) {
+            sh(script: """\
+./kci_rootfs \
+upload \
+--db-token ${API_TOKEN} \
+--api ${params.KCI_API_URL} \
+--rootfs-dir ${pipeline_version} \
+--upload-path images/rootfs/debian/${config}/${pipeline_version}
+""")
+        }
+    }
+}

--- a/jobs/rootfs-builder.jpl
+++ b/jobs/rootfs-builder.jpl
@@ -44,7 +44,22 @@ PIPELINE_VERSION
 @Library('kernelci') _
 import org.kernelci.util.Job
 
-def build(config, arch, pipeline_version, kci_core) {
+def build_buildroot(config, arch, pipeline_version, kci_core) {
+    dir(kci_core) {
+        sh(script: """\
+git clone https://github.com/kernelci/buildroot
+./kci_rootfs \
+build \
+--rootfs-config ${config} \
+--arch ${arch} \
+--data-path buildroot
+mkdir -p ${pipeline_version}
+mv buildroot/output/images/* ${pipeline_version}
+""")
+    }
+}
+
+def build_debos(config, arch, pipeline_version, kci_core) {
     dir(kci_core) {
         sh(script: """\
 ./kci_rootfs \
@@ -80,7 +95,14 @@ node("debos && docker") {
     def config = "${params.ROOTFS_CONFIG}"
     def arch = "${params.ROOTFS_ARCH}"
     def pipeline_version =  "${params.PIPELINE_VERSION}"
-    def docker_image = "${params.DOCKER_BASE}debos"
+    def docker_image = " "
+    def rootfs_type = "${params.ROOTFS_TYPE}"
+
+    if (rootfs_type == "buildroot") {
+        docker_image = "${params.DOCKER_BASE}buildroot"
+    } else if (rootfs_type == "debos") {
+        docker_image = "${params.DOCKER_BASE}debos"
+    }
 
     print("""\
     Config:    ${config}
@@ -101,11 +123,19 @@ node("debos && docker") {
     j.dockerPullWithRetry(docker_image).
         inside(" --privileged --device /dev/kvm ") {
 
+    if (rootfs_type == "buildroot") {
         stage("Build") {
             timeout(time: 8, unit: 'HOURS') {
-	        build(config, arch, pipeline_version, kci_core)
+	        build_buildroot(config, arch, pipeline_version, kci_core)
             }
         }
+    } else if (rootfs_type == "debos") {
+        stage("Build") {
+            timeout(time: 8, unit: 'HOURS') {
+	        build_debos(config, arch, pipeline_version, kci_core)
+            }
+        }
+     }
 
         stage("Upload") {
             timeout(time: 30, unit: 'MINUTES') {

--- a/jobs/rootfs-trigger.jenkinsfile
+++ b/jobs/rootfs-trigger.jenkinsfile
@@ -1,0 +1,107 @@
+#!/usr/bin/env groovy
+
+kci_core_url = "${env.KCI_CORE_URL}"
+kci_core_branch = "${env.KCI_CORE_BRANCH}"
+docker_image = "${env.DOCKER_BASE}debos"
+rootfs_arch = "${params.ROOTFS_ARCH}"
+rootfs_config = "${params.ROOTFS_CONFIG}"
+rootfs_type = "${params.ROOTFS_TYPE}"
+
+def configs = []
+
+println "------------------------------------------------------------------------------------"
+println "Config: ${params.ROOTFS_CONFIG} CPU arch: ${params.ROOTFS_ARCH} Container: ${docker_image}"
+println "------------------------------------------------------------------------------------"
+
+pipeline {
+
+  options {
+    timestamps()
+  }
+  agent {
+    label 'debos && docker'
+  }
+  
+ environment {
+    pipeline_version = VersionNumber(versionNumberString: '${BUILD_DATE_FORMATTED,"yyyyMMdd"}.${BUILDS_TODAY_Z}')
+  }
+
+  stages {
+    stage('Init') {
+        steps {
+            git branch: '${kci_core_branch}', url: '${kci_core_url}'
+        }
+    }
+
+    stage("Configs") {
+        steps {
+            script {  sh "echo ${kci_core_url} ${kci_core_branch} ${rootfs_arch}" }
+            listVariants(".", configs, "${rootfs_config}", "${rootfs_arch}")
+        }
+    }
+        
+   stage("Build") {
+       steps {
+       script {
+        def builds = [:]
+        def i = 0
+
+        for (item in configs) {
+              def config_name = item[0]
+              def arch = item[1]
+              def step_name = "${i} ${config_name} ${arch}"
+              print(step_name)
+
+              builds[step_name] = {
+                   build job: "test-rootfs-builder", parameters: [
+                         string(name: 'ROOTFS_CONFIG', value: "${ROOTFS_CONFIG}"),
+                         string(name: 'ROOTFS_ARCH', value: "${arch}"),
+                         string(name: 'ROOTFS_TYPE', value: "${rootfs_type}"),
+                         string(name: 'KCI_CORE_URL', value: "${kci_core_url}"),
+                         string(name: 'KCI_CORE_BRANCH', value: "${kci_core_branch}"),
+                         string(name: 'PIPELINE_VERSION', value: "${pipeline_version}")
+                    ]
+              }
+              i += 1
+         }
+        parallel builds
+       }
+       }
+    }   
+  }
+
+  post {
+    cleanup {
+      deleteDir()
+    }
+  }
+}
+
+def listVariants(kci_core, config_list, rootfs_config, rootfs_arch) {
+    def cli_opts = ' '
+
+    if (rootfs_config) {
+        cli_opts += " --rootfs-config ${rootfs_config}"
+    }
+
+    if (rootfs_arch) {
+        cli_opts += " --arch ${rootfs_arch}"
+    }
+
+    dir(kci_core) {
+        def rootfs_config_list_raw = sh(script: """\
+./kci_rootfs \
+list_variants \
+${cli_opts}
+""", returnStdout: true).trim()
+
+        def rootfs_config_list =  rootfs_config_list_raw.tokenize('\n')
+
+        for (String rootfs_config_raw: rootfs_config_list) {
+            def data = rootfs_config_raw.tokenize(' ')
+            def config = data[0]
+            def arch = data[1]
+            config_list.add([config, arch])
+        }
+    }
+}

--- a/jobs/rootfs-trigger.jpl
+++ b/jobs/rootfs-trigger.jpl
@@ -68,13 +68,14 @@ ${cli_opts}
 }
 
 
-def buildRootfsStep(job, config ,arch) {
+def buildRootfsStep(job, config ,arch, rootfs_type) {
     def pipeline_version = VersionNumber(
         versionNumberString: '${BUILD_DATE_FORMATTED,"yyyyMMdd"}.${BUILDS_TODAY_Z}')
 
     def str_params = [
         'ROOTFS_CONFIG': config,
         'ROOTFS_ARCH': arch,
+        'ROOTFS_TYPE' : rootfs_type,
         'PIPELINE_VERSION':pipeline_version,
         'KCI_CORE_URL': "${params.KCI_CORE_URL}",
         'KCI_CORE_BRANCH': "${params.KCI_CORE_BRANCH}",
@@ -95,6 +96,7 @@ node("docker && build-trigger") {
     def kci_core = "${env.WORKSPACE}/kernelci-core"
     def docker_image = "${params.DOCKER_BASE}debos"
     def configs = []
+    def rootfs_type = "${params.ROOTFS_TYPE}"
 
     print("""\
     Config:    ${params.ROOTFS_CONFIG}
@@ -126,7 +128,7 @@ node("docker && build-trigger") {
                 print(step_name)
 
                 builds[step_name] = buildRootfsStep(
-                    "rootfs-builder", config_name, arch)
+                    "rootfs-builder", config_name, arch, rootfs_type)
 
                 i += 1
             }


### PR DESCRIPTION
Convert existing rootfs jobs into declarative pipeline jobs.

Signed-off-by: lakshmipathi ganapathi <lakshmipathi.ganapathi@collabora.com>