### PR TITLE
jobs.groovy: Add ROOTFS_TYPE param for rootfs trigger and builder jobs

### DIFF
--- a/jobs.groovy
+++ b/jobs.groovy
@@ -239,6 +239,7 @@ pipelineJob('rootfs-build-trigger') {
     stringParam('DOCKER_BASE', KCI_DOCKER_BASE, 'Dockerhub base address used for the rootfs build images.')
     stringParam('ROOTFS_CONFIG','','Name of the rootfs configuration, all rootfs will be built by default.')
     stringParam('ROOTFS_ARCH','','Name of the rootfs arch config, all given arch will be built by default.')
+    stringParam('ROOTFS_TYPE','debos','Name of the rootfs type which can be debos or buildroot.')
   }
 }
 
@@ -274,6 +275,7 @@ pipelineJob('rootfs-builder') {
     stringParam('DOCKER_BASE', KCI_DOCKER_BASE, 'Dockerhub base address used for the rootfs build images.')
     stringParam('ROOTFS_CONFIG','','Name of the rootfs configuration, all rootfs will be built by default.')
     stringParam('ROOTFS_ARCH','','Name of the rootfs arch config, all given arch will be built by default.')
+    stringParam('ROOTFS_TYPE','debos','Name of the rootfs type which can be debos or buildroot.')
     stringParam('PIPELINE_VERSION','','Unique string identifier for the series of rootfs build jobs.')
   }
 }


### PR DESCRIPTION
Signed-off-by: lakshmipathi.g <lakshmipathi.ganapathi@collabora.com>