### PR TITLE
jobs/bisect.jpl: fix Docker image name without build- prefix

### DIFF
--- a/jobs/bisect.jpl
+++ b/jobs/bisect.jpl
@@ -787,7 +787,7 @@ ${params_summary}""")
         j.cloneKciCore(kci_core, params.KCI_CORE_URL, params.KCI_CORE_BRANCH)
         build_env_docker_image = j.dockerImageName(
             kci_core, params.BUILD_ENVIRONMENT, params.ARCH)
-        docker_image = "${params.DOCKER_BASE}build-${build_env_docker_image}"
+        docker_image = "${params.DOCKER_BASE}${build_env_docker_image}"
     }
 
     j.dockerPullWithRetry(docker_image).inside() {


### PR DESCRIPTION
The Docker toolchain images have been renamed without the build-
prefix, so update the bisection job accordingly.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>