### PR TITLE
jobs/build-trigger.jpl: don't generate fragments in tarball

### DIFF
--- a/jobs/build-trigger.jpl
+++ b/jobs/build-trigger.jpl
@@ -114,13 +114,6 @@ update_last_commit \
 --db-token=${SECRET} \
 """)
 
-            sh(script: """\
-./kci_build \
-generate_fragments \
---build-config=${config} \
---kdir=${kdir} \
-""")
-
             opts['tarball_url'] = sh(script: """\
 ./kci_build \
 push_tarball \


### PR DESCRIPTION
Stop generating kernel config fragments in the source tarball as this
can now be done in each kernel build.  It means the tarball is now
purely the kernel source code with no changes, and build
configurations don't need to list the fragments at the top level any
more.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>