### PR TITLE
jobs/build-trigger.jpl: generate the fragments to list all configs

### DIFF
--- a/jobs/build-trigger.jpl
+++ b/jobs/build-trigger.jpl
@@ -129,6 +129,13 @@ push_tarball \
 
 def listConfigs(config, kci_core, kdir, config_list) {
     dir(kci_core) {
+            sh(script: """\
+./kci_build \
+generate_fragments \
+--build-config=${config} \
+--kdir=${kdir} \
+""")
+
         def kernel_config_list_raw = sh(script: """\
 ./kci_build \
 list_kernel_configs \


### PR DESCRIPTION
The fragment files need to be present in order for a build config to
be scheduled with it.  Generate the fragment files again but in the
step that lists the build configs rather than when uploading the
source tarball like it was done previously.

Fixes: e243cee9e129 ("jobs/build-trigger.jpl: don't generate fragments in tarball")
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>