### PR TITLE
jobs.groovy: use the 'main' branch for rootfs builds

### DIFF
--- a/jobs.groovy
+++ b/jobs.groovy
@@ -215,7 +215,7 @@ pipelineJob('rootfs-build-trigger') {
       lightweight(true)
       scm {
         git {
-          branch(KCI_JENKINS_BRANCH)
+          branch('main')
           remote {
             url(KCI_JENKINS_URL)
           }
@@ -248,7 +248,7 @@ pipelineJob('rootfs-builder') {
       lightweight(true)
       scm {
         git {
-          branch(KCI_JENKINS_BRANCH)
+          branch('main')
           remote {
             url(KCI_JENKINS_URL)
           }


### PR DESCRIPTION
Use the 'main' branch from kernelci-core for rootfs builds as they are
typically run before the kernelci.org branch gets updated.  This is to
allow testing the new rootfs images on staging ahead of the actual
production release.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>