### PR TITLE
Add ssh-agent plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,6 @@ FROM $jenkins_docker_image
 
 ARG config=/config
 COPY plugins*.txt /usr/share/jenkins/ref/
-RUN cat /usr/share/jenkins/ref/plugins*.txt | /usr/local/bin/install-plugins.sh
+RUN cat /usr/share/jenkins/ref/plugins*.txt > /usr/share/jenkins/ref/plugins-all.txt
+RUN /bin/jenkins-plugin-cli --plugin-file /usr/share/jenkins/ref/plugins-all.txt
 COPY $config /config/

--- a/plugins-base.txt
+++ b/plugins-base.txt
@@ -19,6 +19,7 @@ workflow-multibranch
 apache-httpcomponents-client-4-api
 ssh-credentials
 ssh-slaves
+ssh-agent
 variant
 lockable-resources
 workflow-support


### PR DESCRIPTION
Use the newer `jenkins-plugin-cli` command to install plugins and add `ssh-agent` to the list of plugins to install.  This will be useful when uploading files using scp in particular.