### PR TITLE
CHROMEOS Increase build timeout for rootfs

### DIFF
--- a/jobs/rootfs-builder.jpl
+++ b/jobs/rootfs-builder.jpl
@@ -118,7 +118,7 @@ node("debos && docker") {
         inside(" --privileged --device /dev/kvm -v /dev:/dev") {
 
         stage("Build") {
-            timeout(time: 8, unit: 'HOURS') {
+            timeout(time: 20, unit: 'HOURS') {
 	        build(config, arch, pipeline_version, kci_core, rootfs_type)
             }
         }


### PR DESCRIPTION
Chromebook builds are estimated to take even more time than vm image,
approximately it took 10 hours on average Core i7.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>