### PR TITLE
jobs/rootfs-trigger.jpl: add PIPELINE_VERSION parameter

### DIFF
--- a/jobs.groovy
+++ b/jobs.groovy
@@ -240,6 +240,7 @@ pipelineJob('rootfs-build-trigger') {
     stringParam('DOCKER_BASE', KCI_DOCKER_BASE, 'Dockerhub base address used for the rootfs build images.')
     stringParam('ROOTFS_CONFIG','','Name of the rootfs configuration, all rootfs will be built by default.')
     stringParam('ROOTFS_ARCH','','Name of the rootfs arch config, all given arch will be built by default.')
+    stringParam('PIPELINE_VERSION','','Unique string identifier for the series of rootfs build jobs.')
   }
 }
 

--- a/jobs/rootfs-trigger.jpl
+++ b/jobs/rootfs-trigger.jpl
@@ -32,6 +32,8 @@ ROOTFS_CONFIG
   Set this to limit the rootfs builds to only one configuration
 ROOTFS_ARCH
   Set this to limit the rootfs builds to only one architecture
+PIPELINE_VERSION
+  Unique string identifier for the series of rootfs build jobs
 */
 
 @Library('kernelci') _
@@ -69,8 +71,13 @@ ${cli_opts}
 
 
 def buildRootfsStep(job, config ,arch, rootfs_type) {
-    def pipeline_version = VersionNumber(
-        versionNumberString: '${BUILD_DATE_FORMATTED,"yyyyMMdd"}.${BUILDS_TODAY_Z}')
+    def pipeline_version = params.PIPELINE_VERSION;
+
+    if (!pipeline_version) {
+        pipeline_version = VersionNumber(
+            versionNumberString:
+            '${BUILD_DATE_FORMATTED,"yyyyMMdd"}.${BUILDS_TODAY_Z}')
+    }
 
     def str_params = [
         'ROOTFS_CONFIG': config,


### PR DESCRIPTION
Add a PIPELINE_VERSION parameter to the rootfs-trigger job to be able
to supply one explicitly.  If the parameter is empty, a pipeline name
will be created automatically like before.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>