### PR TITLE
jobs/{monitor,build-trigger}.jpl: update last commit in monitor

### DIFF
--- a/jobs.groovy
+++ b/jobs.groovy
@@ -78,6 +78,7 @@ pipelineJob('kernel-build-trigger') {
   }
   parameters {
     stringParam('BUILD_CONFIG', '', 'Name of the build configuration.')
+    stringParam('COMMIT_ID', '', 'Git commit SHA1 at the revision of the snapshot')
     booleanParam('PUBLISH', true, 'Publish build results via the KernelCI backend API')
     booleanParam('EMAIL', true, 'Send build results via email')
     stringParam('LABS_WHITELIST', KCI_LABS_LIST, 'List of labs to include in the tests, all labs will be tested by default.')

--- a/jobs/build-trigger.jpl
+++ b/jobs/build-trigger.jpl
@@ -24,6 +24,8 @@
 
 BUILD_CONFIG
   Name of the build configuration
+COMMIT_ID
+  Git commit SHA1 at the revision of the snapshot
 PUBLISH (boolean)
   Publish build results via the KernelCI backend API
 EMAIL (boolean)
@@ -49,23 +51,7 @@ ALLOW_REBUILD (false)
 @Library('kernelci') _
 import org.kernelci.util.Job
 
-def configAlreadyBuilt(config, kci_core) {
-    def new_commit = null
-
-    dir(kci_core) {
-        new_commit = sh(
-        script: """\
-./kci_build \
-check_new_commit \
---build-config=${config} \
---storage=${params.KCI_STORAGE_URL} \
-""", returnStdout: true).trim()
-    }
-
-    return (new_commit == "")
-}
-
-def pushTarball(config, kci_core, mirror, kdir, opts) {
+def updateRepo(config, kci_core, mirror, kdir, opts) {
     dir(kci_core) {
         sh(script: """\
 ./kci_build \
@@ -102,18 +88,13 @@ describe \
         opts['commit'] = describe_list[0]
         opts['describe'] = describe_list[1]
         opts['describe_verbose'] = describe_list[2]
+    }
+}
 
+def pushTarball(config, kci_core, kdir, opts) {
+    dir(kci_core) {
         withCredentials([string(credentialsId: params.KCI_API_TOKEN_ID,
                                 variable: 'SECRET')]) {
-            sh(script: """\
-./kci_build \
-update_last_commit \
---build-config=${config} \
---commit=${opts['commit']} \
---api=${params.KCI_API_URL} \
---db-token=${SECRET} \
-""")
-
             opts['tarball_url'] = sh(script: """\
 ./kci_build \
 push_tarball \
@@ -340,6 +321,7 @@ node("docker && build-trigger") {
 
     print("""\
     Config:    ${params.BUILD_CONFIG}
+    Commit:    ${params.COMMIT_ID}
     Container: ${docker_image}""")
 
     j.dockerPullWithRetry(docker_image).inside() {
@@ -349,14 +331,6 @@ node("docker && build-trigger") {
             timeout(time: 15, unit: 'MINUTES') {
                 j.cloneKciCore(
                     kci_core, params.KCI_CORE_URL, params.KCI_CORE_BRANCH)
-            }
-        }
-
-        if (params.ALLOW_REBUILD != true) {
-            if (configAlreadyBuilt(params.BUILD_CONFIG, kci_core)) {
-                print("Revision already built, aborting")
-                currentBuild.result = 'ABORTED'
-                return
             }
         }
 
@@ -410,8 +384,20 @@ get_lab_info \
             }
         }
 
+        stage("Repo") {
+            updateRepo(params.BUILD_CONFIG, kci_core, mirror, kdir, opts)
+        }
+
+        if (params.ALLOW_REBUILD != true) {
+            if (opts['commit'] != params.COMMIT_ID) {
+                print("Commit mismatch: ${params.COMMIT_ID} ${opts['commit']}")
+                currentBuild.result = 'ABORTED'
+                return
+            }
+        }
+
         stage("Tarball") {
-            pushTarball(params.BUILD_CONFIG, kci_core, mirror, kdir, opts)
+            pushTarball(params.BUILD_CONFIG, kci_core, kdir, opts)
         }
 
         stage("Configs") {

--- a/jobs/monitor.jpl
+++ b/jobs/monitor.jpl
@@ -29,7 +29,7 @@ CONFIG_LIST
   List of build configs to check instead of all the ones in build-configs.yaml
 KCI_API_URL (https://api.kernelci.org)
   URL of the KernelCI backend API
-KCI_TOKEN_ID
+KCI_API_TOKEN_ID
   Identifier of the KernelCI backend API token stored in Jenkins
 KCI_STORAGE_URL (https://storage.kernelci.org/)
   URL of the KernelCI storage server
@@ -39,11 +39,26 @@ KCI_CORE_BRANCH (master)
   Name of the branch to use in the kernelci-core repository
 DOCKER_BASE (kernelci/)
   Dockerhub base address used for the build images
-
 */
 
 @Library('kernelci') _
 import org.kernelci.util.Job
+
+def updateLastCommit(config, commit, kci_core) {
+    dir(kci_core) {
+        withCredentials([string(credentialsId: params.KCI_API_TOKEN_ID,
+                                variable: 'SECRET')]) {
+            sh(script: """\
+./kci_build \
+update_last_commit \
+--build-config=${config} \
+--commit=${commit} \
+--api=${params.KCI_API_URL} \
+--db-token=${SECRET} \
+""")
+        }
+    }
+}
 
 def checkConfig(config, kci_core) {
     def retry = 3
@@ -58,7 +73,7 @@ def checkConfig(config, kci_core) {
 check_new_commit \
 --build-config=${config} \
 --storage=${params.KCI_STORAGE_URL} \
-""", returnStdout: true)
+""", returnStdout: true).trim()
                 retry = 0
             } catch (error) {
 
@@ -79,9 +94,12 @@ check_new_commit \
 
     print("${config}: triggering build")
 
+    updateLastCommit(config, commit, kci_core)
+
     def job = "kernel-build-trigger"
     def str_params = [
         'BUILD_CONFIG': config,
+        'COMMIT_ID': commit,
     ]
     def job_params = []
     def j = new Job()


### PR DESCRIPTION
Rework how the last commit is being handled by updating it in the
monitor job rather than the build-trigger job.  This avoids scheduling
potentially many duplicate build-trigger jobs when the queue is
already full.  Instead, pass the git commit sha1 to the build-trigger
job and only build if it the current branch matches that.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>