### PR TITLE
jobs/*.jpl: update all copyright headers

### DIFF
--- a/jobs/bisect.jpl
+++ b/jobs/bisect.jpl
@@ -1,7 +1,7 @@
 #!/usr/bin/env groovy
 
 /*
-  Copyright (C) 2017, 2018, 2019 Collabora Limited
+  Copyright (C) 2017-2021 Collabora Limited
   Author: Guillaume Tucker <guillaume.tucker@collabora.com>
 
   This module is free software; you can redistribute it and/or modify it under

--- a/jobs/build-trigger.jpl
+++ b/jobs/build-trigger.jpl
@@ -1,7 +1,7 @@
 #!/usr/bin/env groovy
 
 /*
-  Copyright (C) 2018, 2019 Collabora Limited
+  Copyright (C) 2018-2022 Collabora Limited
   Author: Guillaume Tucker <guillaume.tucker@collabora.com>
 
   This module is free software; you can redistribute it and/or modify it under

--- a/jobs/build.jpl
+++ b/jobs/build.jpl
@@ -1,7 +1,7 @@
 #!/usr/bin/env groovy
 
 /*
-  Copyright (C) 2018 Collabora Limited
+  Copyright (C) 2018-2021 Collabora Limited
   Author: Guillaume Tucker <guillaume.tucker@collabora.com>
 
   This module is free software; you can redistribute it and/or modify it under

--- a/jobs/monitor.jpl
+++ b/jobs/monitor.jpl
@@ -1,7 +1,7 @@
 #!/usr/bin/env groovy
 
 /*
-  Copyright (C) 2018, 2019 Collabora Limited
+  Copyright (C) 2018-2022 Collabora Limited
   Author: Guillaume Tucker <guillaume.tucker@collabora.com>
 
   This module is free software; you can redistribute it and/or modify it under

--- a/jobs/rootfs-builder.jpl
+++ b/jobs/rootfs-builder.jpl
@@ -1,8 +1,10 @@
 #!/usr/bin/env groovy
 
 /*
-  Copyright (C) 2020 Collabora Limited
+  Copyright (C) 2020-2022 Collabora Limited
   Author: Lakshmipathi Ganapathi <lakshmipathi.ganapathi@collabora.com>
+  Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+  Author: Denys Fedoryshchenko <denys.f@collabora.com>
 
   This module is free software; you can redistribute it and/or modify it under
   the terms of the GNU Lesser General Public License as published by the Free

--- a/jobs/rootfs-trigger.jpl
+++ b/jobs/rootfs-trigger.jpl
@@ -1,8 +1,9 @@
 #!/usr/bin/env groovy
 
 /*
-  Copyright (C) 2020 Collabora Limited
+  Copyright (C) 2020-2022 Collabora Limited
   Author: Lakshmipathi Ganapathi <lakshmipathi.ganapathi@collabora.com>
+  Author: Guillaume Tucker <guillaume.tucker@collabora.com>
 
   This module is free software; you can redistribute it and/or modify it under
   the terms of the GNU Lesser General Public License as published by the Free

--- a/jobs/test-runner.jpl
+++ b/jobs/test-runner.jpl
@@ -1,7 +1,7 @@
 #!/usr/bin/env groovy
 
 /*
-  Copyright (C) 2019 Collabora Limited
+  Copyright (C) 2019-2021 Collabora Limited
   Author: Guillaume Tucker <guillaume.tucker@collabora.com>
 
   This module is free software; you can redistribute it and/or modify it under


### PR DESCRIPTION
Update the copyright headers for all the Jenkins job files with
authors and years.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>