### PR TITLE
build-trigger.jpl: build gki_defconfig on k8s-big nodes

### DIFF
--- a/jobs/build-trigger.jpl
+++ b/jobs/build-trigger.jpl
@@ -244,7 +244,7 @@ def buildKernelStep(job, arch, defconfig, build_env, opts, labs, kci_core) {
     def node_label = "k8s"
     def parallel_builds = "4"
 
-    if (defconfig.matches(".*allmodconfig.*")) {
+    if (defconfig.matches(".*allmodconfig.*") || defconfig.matches("^gki_defconfig.*")) {
         node_label = "k8s-big"
         parallel_builds = ""
     } else if (defconfig.matches("^defconfig.*") && arch == "arm64") {


### PR DESCRIPTION
As reported in kernelci maillist, gki_defconfig fails to build,
during testing we discovered that during linking, because of LTO
build process might consume more than 18Gbyte of RAM, which
exceed capacity of normal builders (4Gbyte).
This patch set gki_defconfig to build on k8s-big nodes,
that have 32Gbyte of RAM.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>