### PR TITLE
CHROMEOS jobs/rootfs-builder.jpl: Fix rootfs image upload path

### DIFF
--- a/jobs/rootfs-builder.jpl
+++ b/jobs/rootfs-builder.jpl
@@ -126,12 +126,26 @@ node("debos && docker") {
         }
 
         stage("Upload") {
+          def rootfs_type_dir = ""
+
+          switch(rootfs_type) {
+            case 'debos':
+              rootfs_type_dir = 'debian'
+              break
+
+            case 'chromiumos':
+              rootfs_type_dir = 'chromeos'
+              break
+
+            default:
+              rootfs_type_dir = rootfs_type
+          }
             sshagent(credentials : ['jenkins-chromeos-storage-private-key']) {
                 sh(script: """\
 ssh \
 -o StrictHostKeyChecking=no \
 -p 22022 \
-chromeos@storage.chromeos.kernelci.org 'mkdir -p ~/images/rootfs/chromeos/${pipeline_version} || true'
+chromeos@storage.chromeos.kernelci.org 'mkdir -p ~/images/rootfs/${rootfs_type_dir}/${config}/${pipeline_version} || true'
 """
                   )
                 sh(script: """\
@@ -139,9 +153,9 @@ scp \
 -o StrictHostKeyChecking=no \
 -P 22022 \
 -r \
-kernelci-core/${pipeline_version}/_install_/* \
+kernelci-core/${pipeline_version}/_install_/${config}/* \
 chromeos@storage.chromeos.kernelci.org:\
-~/images/rootfs/chromeos/${pipeline_version}
+~/images/rootfs/${rootfs_type_dir}/${config}/${pipeline_version}
 """
                   )
             }


### PR DESCRIPTION
Set rootfs image upload path to
rootfs/${rootfs_type}/${config}/${pipeline_version} previous setting
made it hard to browse through the artifacts from different builds as it
the builds were grouped by pipeline version before config names.

Signed-off-by: Michal Galka <michal.galka@collabora.com>