### PR TITLE
CHROMEOS jobs/rootfs-builder.jpl: use cros-sdk image to build Chromium OS

### DIFF
--- a/jobs/rootfs-builder.jpl
+++ b/jobs/rootfs-builder.jpl
@@ -100,6 +100,10 @@ node("debos && docker") {
     def rootfs_type = "${params.ROOTFS_TYPE}"
     def docker_image = "${params.DOCKER_BASE}${rootfs_type}"
 
+    if (rootfs_type == "chromiumos") {
+        docker_image = "kernelci/cros-sdk"
+    }
+
     print("""\
     Config:    ${config}
     CPU arch:  ${arch}


### PR DESCRIPTION
Use the kernelci/cros-sdk image to build Chromium OS user-space
images.  This Docker image can also be used to build other things from
the Chromium OS source tree such as Depthcharge firmware and kernels,
which is why it doesn't match the rootfs type name.

Depends on https://github.com/kernelci/kernelci-core/pull/1203
