### PR TITLE
CHROMEOS jobs/rootfs-builder.jpl: drop build timeout

### DIFF
--- a/jobs/rootfs-builder.jpl
+++ b/jobs/rootfs-builder.jpl
@@ -124,9 +124,7 @@ node("debos && docker") {
         inside(" --privileged --device /dev/kvm -v /dev:/dev") {
 
         stage("Build") {
-            timeout(time: 20, unit: 'HOURS') {
-	        build(config, arch, pipeline_version, kci_core, rootfs_type)
-            }
+	    build(config, arch, pipeline_version, kci_core, rootfs_type)
         }
 
         stage("Upload") {


### PR DESCRIPTION
The Chrome OS images take a very long time to complete, potentially
over 24h on regular builders.  Drop the timeout as it's too easy to
reach it and since jobs are started by hand it's not an issue if they
need to be also canceled by hand.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>