### PR TITLE
CHROMEOS rootfs-builder.jpl: Make docker base configurable again

### DIFF
--- a/jobs/rootfs-builder.jpl
+++ b/jobs/rootfs-builder.jpl
@@ -103,7 +103,7 @@ node("debos && docker") {
     def docker_image = "${params.DOCKER_BASE}${rootfs_type}"
 
     if (rootfs_type == "chromiumos") {
-        docker_image = "kernelci/cros-sdk"
+        docker_image = "${params.DOCKER_BASE}cros-sdk"
     }
 
     print("""\


### PR DESCRIPTION
Sometimes we need to test alternative cros-sdk docker images,
and for that base need to be configurable.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>