### PR TITLE
Use kci_docker images for kernel builds

### DIFF
--- a/jobs/build.jpl
+++ b/jobs/build.jpl
@@ -74,7 +74,7 @@ node("docker" && params.NODE_LABEL) {
     def k8s_context = "${env.K8S_CONTEXT}"
     def docker_image = null
 
-        print("""\
+    print("""\
     Config:    ${params.BUILD_CONFIG}
     CPU arch:  ${params.ARCH}
     Describe:  ${params.GIT_DESCRIBE}
@@ -83,7 +83,7 @@ node("docker" && params.NODE_LABEL) {
     Compiler:  ${params.BUILD_ENVIRONMENT}
     K8S ctx:   ${k8s_context}""")
 
-    docker_image = "${params.DOCKER_BASE}k8s"
+    docker_image = "${params.DOCKER_BASE}k8s:kernelci"
     j.dockerPullWithRetry(docker_image).inside("-v $HOME/.kube:/.kube -v $HOME/.config/gcloud:/.config/gcloud -v $HOME/.azure:/.azure") {
         j.cloneKciCore(kci_core, params.KCI_CORE_URL, params.KCI_CORE_BRANCH)
         build_env_docker_image = j.dockerImageName(

--- a/src/org/kernelci/util/Job.groovy
+++ b/src/org/kernelci/util/Job.groovy
@@ -58,7 +58,9 @@ def dockerImageName(kci_core, build_env, kernel_arch) {
         def cc_arch = build_env_data[3]
 
         if (cc_arch)
-            image_name = "${build_env}_${cc_arch}"
+            image_name = "${build_env}:${cc_arch}-kselftest-kernelci"
+        else
+            image_name = "${build_env}:kselftest-kernelci"
     }
 
     return image_name

--- a/src/org/kernelci/util/Job.groovy
+++ b/src/org/kernelci/util/Job.groovy
@@ -57,7 +57,9 @@ def dockerImageName(kci_core, build_env, kernel_arch) {
         def build_env_data = build_env_raw.split('\n').toList()
         def cc_arch = build_env_data[3]
 
-        if (cc_arch)
+        if (cc_arch == 'sparc') /* No kselftest variant for sparc */
+            image_name = "${build_env}:${cc_arch}-kernelci"
+        else if (cc_arch)
             image_name = "${build_env}:${cc_arch}-kselftest-kernelci"
         else
             image_name = "${build_env}:kselftest-kernelci"


### PR DESCRIPTION
Update the Docker image names to use the ones produced by `kci_docker`, both with the Kubernetes tools used in Jenkins and the compiler toolchains running in Kubernetes.