### PR TITLE
rootfs-builder.jpl: use new Docker images with :kernelci

### DIFF
--- a/jobs/rootfs-builder.jpl
+++ b/jobs/rootfs-builder.jpl
@@ -89,7 +89,7 @@ node("debos && docker") {
     def arch = "${params.ROOTFS_ARCH}"
     def pipeline_version =  "${params.PIPELINE_VERSION}"
     def rootfs_type = "${params.ROOTFS_TYPE}"
-    def docker_image = "${params.DOCKER_BASE}${rootfs_type}"
+    def docker_image = "${params.DOCKER_BASE}${rootfs_type}:kernelci"
 
     print("""\
     Config:    ${config}


### PR DESCRIPTION
Use the new Docker images with the kernelci fragment added.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>