### PR TITLE
build-trigger: add minimal bmeta.json in tarball

### DIFF
--- a/jobs/build-trigger.jpl
+++ b/jobs/build-trigger.jpl
@@ -95,6 +95,8 @@ def pushTarball(config, kci_core, kdir, opts) {
     dir(kci_core) {
         withCredentials([string(credentialsId: params.KCI_API_TOKEN_ID,
                                 variable: 'SECRET')]) {
+            sh(script: "./kci_build init_bmeta --build-config=${config} --kdir=${kdir}")
+
             opts['tarball_url'] = sh(script: """\
 ./kci_build \
 push_tarball \


### PR DESCRIPTION
Add a minimal bmeta.json to the tarball.  This makes is easier for
downstream tools using kernelci tarballs to know exactly the tree,
branch, describe, URL etc. where the source originated without having
to decode it from the tarball URL.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>