### PR TITLE
jobs/*.jpl: use kernelci Docker image rather than build-base

### DIFF
--- a/jobs/bisect.jpl
+++ b/jobs/bisect.jpl
@@ -783,7 +783,7 @@ ${params_summary}""")
         }
     }
 
-    j.dockerPullWithRetry("${params.DOCKER_BASE}build-base").inside() {
+    j.dockerPullWithRetry("${params.DOCKER_BASE}kernelci").inside() {
         j.cloneKciCore(kci_core, params.KCI_CORE_URL, params.KCI_CORE_BRANCH)
         build_env_docker_image = j.dockerImageName(
             kci_core, params.BUILD_ENVIRONMENT, params.ARCH)

--- a/jobs/build-trigger.jpl
+++ b/jobs/build-trigger.jpl
@@ -314,7 +314,7 @@ node("docker && build-trigger") {
     def kdir = "${env.WORKSPACE}/configs/${params.BUILD_CONFIG}"
     def mirror = "${env.WORKSPACE}/linux.git"
     def labs_info = "${env.WORKSPACE}/labs"
-    def docker_image = "${params.DOCKER_BASE}build-base"
+    def docker_image = "${params.DOCKER_BASE}kernelci"
     def opts = [:]
     def configs = []
     def buildStatus = null

--- a/jobs/monitor.jpl
+++ b/jobs/monitor.jpl
@@ -111,7 +111,7 @@ check_new_commit \
 node("docker && monitor") {
     def j = new Job()
     def kci_core = env.WORKSPACE + '/kernelci-core'
-    def docker_image = "${params.DOCKER_BASE}build-base"
+    def docker_image = "${params.DOCKER_BASE}kernelci"
 
     print("""\
     Storage:   ${params.KCI_STORAGE_URL}

--- a/jobs/rootfs-trigger.jpl
+++ b/jobs/rootfs-trigger.jpl
@@ -102,7 +102,7 @@ def buildRootfsStep(job, config ,arch, rootfs_type) {
 node("docker && rootfs-trigger") {
     def j = new Job()
     def kci_core = "${env.WORKSPACE}/kernelci-core"
-    def docker_image = "${params.DOCKER_BASE}build-base"
+    def docker_image = "${params.DOCKER_BASE}kernelci"
     def configs = []
 
     print("""\

--- a/jobs/test-runner.jpl
+++ b/jobs/test-runner.jpl
@@ -112,7 +112,7 @@ node("docker && test-runner") {
     def kci_core = "${env.WORKSPACE}/kernelci-core"
     def jobs_dir = "${env.WORKSPACE}/jobs"
     def artifacts = "${env.WORKSPACE}/artifacts"
-    def docker_image = "${params.DOCKER_BASE}build-base"
+    def docker_image = "${params.DOCKER_BASE}kernelci"
     def labs = params.LABS.tokenize(' ')
     def labs_submit = []
 


### PR DESCRIPTION
Use the new kernelci image (or kernelci/staging-kernelci on staging using DOCKER_BASE) instead of build-base which is now deprecated.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>