### PR TITLE
Use kernelci package from Docker image

### DIFF
--- a/jobs/bisect.jpl
+++ b/jobs/bisect.jpl
@@ -786,7 +786,7 @@ ${params_summary}""")
     j.dockerPullWithRetry("${params.DOCKER_BASE}kernelci").inside() {
         j.cloneKciCore(kci_core, params.KCI_CORE_URL, params.KCI_CORE_BRANCH)
         build_env_docker_image = j.dockerImageName(
-            kci_core, params.BUILD_ENVIRONMENT, params.ARCH)
+            params.BUILD_ENVIRONMENT, params.ARCH)
         docker_image = "${params.DOCKER_BASE}${build_env_docker_image}"
     }
 

--- a/jobs/build-trigger.jpl
+++ b/jobs/build-trigger.jpl
@@ -38,10 +38,6 @@ KCI_API_TOKEN_ID
   Identifier of the KernelCI backend API token stored in Jenkins
 KCI_STORAGE_URL (https://storage.kernelci.org/)
   URL of the KernelCI storage server
-KCI_CORE_URL (https://github.com/kernelci/kernelci-core.git)
-  URL of the kernelci-core repository
-KCI_CORE_BRANCH (master)
-  Name of the branch to use in the kernelci-core repository
 DOCKER_BASE (kernelci/)
   Dockerhub base address used for the build images
 ALLOW_REBUILD (false)
@@ -51,52 +47,49 @@ ALLOW_REBUILD (false)
 @Library('kernelci') _
 import org.kernelci.util.Job
 
-def updateRepo(config, kci_core, mirror, kdir, opts) {
-    dir(kci_core) {
-        sh(script: """\
-./kci_build \
+def updateRepo(config, mirror, kdir, opts) {
+    sh(script: """\
+kci_build \
 update_mirror \
 --build-config=${config} \
 --mirror=${mirror} \
 """)
 
-        while (true) {
-            try {
-                sh(script: """\
-./kci_build \
+    while (true) {
+        try {
+            sh(script: """\
+kci_build \
 update_repo \
 --build-config=${config} \
 --kdir=${kdir} \
 --mirror=${mirror} \
 """)
-                break
-            } catch (error) {
-                print("Failed to update repo: ${error}")
-                print("Removing clone and retrying")
-                sh(script: "rm -rf ${kdir}")
-                sleep 1
-            }
+            break
+        } catch (error) {
+            print("Failed to update repo: ${error}")
+            print("Removing clone and retrying")
+            sh(script: "rm -rf ${kdir}")
+            sleep 1
         }
+    }
 
-        def describe_raw = sh(script: """\
-./kci_build \
+    def describe_raw = sh(script: """\
+kci_build \
 describe \
 --build-config=${config} \
 --kdir=${kdir} \
 """, returnStdout: true).trim()
-        def describe_list = describe_raw.tokenize('\n')
-        opts['commit'] = describe_list[0]
-        opts['describe'] = describe_list[1]
-        opts['describe_verbose'] = describe_list[2]
-    }
+    def describe_list = describe_raw.tokenize('\n')
+    opts['commit'] = describe_list[0]
+    opts['describe'] = describe_list[1]
+    opts['describe_verbose'] = describe_list[2]
 }
 
-def pushTarball(config, kci_core, kdir, opts) {
-    dir(kci_core) {
-        withCredentials([string(credentialsId: params.KCI_API_TOKEN_ID,
-                                variable: 'SECRET')]) {
-            opts['tarball_url'] = sh(script: """\
-./kci_build \
+def pushTarball(config, kdir, opts) {
+    withCredentials([string(credentialsId: params.KCI_API_TOKEN_ID,
+                            variable: 'SECRET')]) {
+        opts['tarball_url'] = sh(script: """\
+kci_build \
 push_tarball \
 --build-config=${config} \
 --kdir=${kdir} \
@@ -104,86 +97,79 @@ push_tarball \
 --api=${params.KCI_API_URL} \
 --db-token=${SECRET} \
 """, returnStdout: true).trim()
-        }
     }
 }
 
-def listConfigs(config, kci_core, kdir, config_list) {
-    dir(kci_core) {
-            sh(script: """\
-./kci_build \
+def listConfigs(config, kdir, config_list) {
+    sh(script: """\
+kci_build \
 generate_fragments \
 --build-config=${config} \
 --kdir=${kdir} \
 """)
 
-        def kernel_config_list_raw = sh(script: """\
-./kci_build \
+    def kernel_config_list_raw = sh(script: """\
+kci_build \
 list_kernel_configs \
 --build-config=${config} \
 --kdir=${kdir} \
 """, returnStdout: true).trim()
-        def kernel_config_list = kernel_config_list_raw.tokenize('\n')
+    def kernel_config_list = kernel_config_list_raw.tokenize('\n')
 
-        for (String kernel_config_raw: kernel_config_list) {
-            def data = kernel_config_raw.tokenize(' ')
-            def arch = data[0]
-            def defconfig = data[1]
-            def build_env = data[2]
-            config_list.add([arch, defconfig, build_env])
-        }
+    for (String kernel_config_raw: kernel_config_list) {
+        def data = kernel_config_raw.tokenize(' ')
+        def arch = data[0]
+        def defconfig = data[1]
+        def build_env = data[2]
+        config_list.add([arch, defconfig, build_env])
     }
 }
 
-def listArchitectures(kci_core, config) {
+def listArchitectures(config) {
     def arch_list = []
 
-    dir(kci_core) {
-        def raw_variants = sh(
-            script: """\
-./kci_build \
+    def raw_variants = sh(
+        script: """\
+kci_build \
 list_variants \
 --build-config=${config} \
 """, returnStdout: true).trim()
-        def variants = raw_variants.tokenize('\n')
+    def variants = raw_variants.tokenize('\n')
 
-        for (String variant: variants) {
-            def raw_variant_arch_list = sh(
-                script: """\
-./kci_build \
+    for (String variant: variants) {
+        def raw_variant_arch_list = sh(
+            script: """\
+kci_build \
 arch_list \
 --build-config=${config} \
 --variant=${variant} \
 """, returnStdout: true).trim()
-            def variant_arch_list = raw_variant_arch_list.tokenize('\n')
+        def variant_arch_list = raw_variant_arch_list.tokenize('\n')
 
-            for (String arch: variant_arch_list)
-                if (!arch_list.contains(arch))
-                    arch_list.add(arch)
-        }
+        for (String arch: variant_arch_list)
+            if (!arch_list.contains(arch))
+                arch_list.add(arch)
     }
 
     return arch_list
 }
 
-def addBuildOpts(config, kci_core, opts) {
-    dir(kci_core) {
-        opts['config'] = config
+def addBuildOpts(config, opts) {
+    opts['config'] = config
 
-        def opts_raw = sh(
-            script: """\
-./kci_build \
+    def opts_raw = sh(
+        script: """\
+kci_build \
 tree_branch \
 --build-config=${config} \
 """, returnStdout: true).trim()
-        def opt_list = opts_raw.tokenize('\n')
-        opts['tree'] = opt_list[0]
-        opts['git_url'] = opt_list[1]
-        opts['branch'] = opt_list[2]
-    }
+    def opt_list = opts_raw.tokenize('\n')
+    opts['tree'] = opt_list[0]
+    opts['git_url'] = opt_list[1]
+    opts['branch'] = opt_list[2]
 }
 
-def getLabsWithTests(build_job_name, number, labs, kci_core) {
+def getLabsWithTests(build_job_name, number, labs) {
     def artifacts = "${env.WORKSPACE}/artifacts-${build_job_name}-${number}"
     def lab_list = []
 
@@ -194,24 +180,22 @@ def getLabsWithTests(build_job_name, number, labs, kci_core) {
         )
     }
 
-    dir(kci_core) {
-        def labs_info = "${env.WORKSPACE}/labs"
+    def labs_info = "${env.WORKSPACE}/labs"
 
-        for (lab in labs) {
-            def lab_json = "${labs_info}/${lab}.json"
+    for (lab in labs) {
+        def lab_json = "${labs_info}/${lab}.json"
 
-            def raw_jobs = sh(script: """\
+        def raw_jobs = sh(script: """\
 #!/bin/sh -e
-./kci_test \
+kci_test \
 list_jobs \
 --lab-config=${lab} \
 --lab-json=${lab_json} \
 --install-path=${artifacts} \
 """, returnStdout: true).trim()
 
-            if (raw_jobs)
-                lab_list.push(lab)
-        }
+        if (raw_jobs)
+            lab_list.push(lab)
     }
 
     sh(script: "rm -rf ${artifacts}")
@@ -219,28 +203,26 @@ list_jobs \
     return lab_list
 }
 
-def scheduleTests(build_job_name, build_job_number, labs, kci_core) {
-    dir(kci_core) {
-        def labs_str = ""
-        for (lab in labs)
-            labs_str += "${lab} "
+def scheduleTests(build_job_name, build_job_number, labs) {
+    def labs_str = ""
+    for (lab in labs)
+        labs_str += "${lab} "
 
-        def str_params = [
-            'LABS': labs_str.trim(),
-            'TRIGGER_JOB_NAME': env.JOB_NAME,
-            'TRIGGER_JOB_NUMBER': env.BUILD_NUMBER,
-            'BUILD_JOB_NAME': build_job_name,
-            'BUILD_JOB_NUMBER': "${build_job_number}",
-        ]
-        def params = []
+    def str_params = [
+        'LABS': labs_str.trim(),
+        'TRIGGER_JOB_NAME': env.JOB_NAME,
+        'TRIGGER_JOB_NUMBER': env.BUILD_NUMBER,
+        'BUILD_JOB_NAME': build_job_name,
+        'BUILD_JOB_NUMBER': "${build_job_number}",
+    ]
+    def params = []
 
-        def j = new Job()
-        j.addStrParams(params, str_params)
-        build(job: 'test-runner', parameters: params, propagate: false)
-    }
+    def j = new Job()
+    j.addStrParams(params, str_params)
+    build(job: 'test-runner', parameters: params, propagate: false)
 }
 
-def buildKernelStep(job, arch, defconfig, build_env, opts, labs, kci_core) {
+def buildKernelStep(job, arch, defconfig, build_env, opts, labs) {
     def node_label = "k8s"
     def parallel_builds = "4"
 
@@ -266,8 +248,6 @@ def buildKernelStep(job, arch, defconfig, build_env, opts, labs, kci_core) {
         'BUILD_ENVIRONMENT': build_env,
         'NODE_LABEL': node_label,
         'PARALLEL_BUILDS': parallel_builds,
-        'KCI_CORE_URL': "${params.KCI_CORE_URL}",
-        'KCI_CORE_BRANCH': "${params.KCI_CORE_BRANCH}",
         'KCI_API_URL': "${params.KCI_API_URL}",
         'KCI_API_TOKEN_ID': "${params.KCI_API_TOKEN_ID}",
         'KCI_STORAGE_URL': "${params.KCI_STORAGE_URL}",
@@ -282,9 +262,9 @@ def buildKernelStep(job, arch, defconfig, build_env, opts, labs, kci_core) {
         def res = build(job: job, parameters: job_params, propagate: false)
         print("${res.number}: ${arch} ${defconfig} ${build_env} ${res.result}")
         if (res.result == "SUCCESS") {
-            def test_labs = getLabsWithTests(job, res.number, labs, kci_core)
+            def test_labs = getLabsWithTests(job, res.number, labs)
             if (test_labs) {
-                scheduleTests(job, res.number, test_labs, kci_core)
+                scheduleTests(job, res.number, test_labs)
             }
         }
     }
@@ -310,7 +290,6 @@ def buildsComplete(job, opts) {
 
 node("docker && build-trigger") {
     def j = new Job()
-    def kci_core = "${env.WORKSPACE}/kernelci-core"
     def kdir = "${env.WORKSPACE}/configs/${params.BUILD_CONFIG}"
     def mirror = "${env.WORKSPACE}/linux.git"
     def labs_info = "${env.WORKSPACE}/labs"
@@ -327,65 +306,56 @@ node("docker && build-trigger") {
     j.dockerPullWithRetry(docker_image).inside() {
         def labs = []
 
-        stage("Init") {
-            timeout(time: 15, unit: 'MINUTES') {
-                j.cloneKciCore(
-                    kci_core, params.KCI_CORE_URL, params.KCI_CORE_BRANCH)
-            }
-        }
-
         stage("Labs") {
             sh(script: "rm -rf ${labs_info}; mkdir -p ${labs_info}")
 
-            dir(kci_core) {
-                def raw_lab_names = sh(
-                    script: "./kci_test list_labs", returnStdout: true).trim()
-                def all_lab_names = raw_lab_names.tokenize('\n')
-                def labs_list = []
+            def raw_lab_names = sh(
+                script: "kci_test list_labs", returnStdout: true).trim()
+            def all_lab_names = raw_lab_names.tokenize('\n')
+            def labs_list = []
 
-                if (params.LABS_WHITELIST) {
-                    def whitelist = params.LABS_WHITELIST.tokenize(' ')
+            if (params.LABS_WHITELIST) {
+                def whitelist = params.LABS_WHITELIST.tokenize(' ')
 
-                    for (lab in all_lab_names)
-                        if (whitelist.contains(lab))
-                            labs_list.add(lab)
-                } else {
-                    labs_list = all_lab_names
-                }
+                for (lab in all_lab_names)
+                    if (whitelist.contains(lab))
+                        labs_list.add(lab)
+            } else {
+                labs_list = all_lab_names
+            }
 
-                for (lab in labs_list) {
-                    def lab_json = "${labs_info}/${lab}.json"
-                    def token = "${lab}-lava-api"
-                    def retry = 3
-                    while (retry--) {
-                        try {
-                            withCredentials([string(credentialsId: token,
-                                                    variable: 'SECRET')]) {
-                                sh(script: """\
-./kci_test \
+            for (lab in labs_list) {
+                def lab_json = "${labs_info}/${lab}.json"
+                def token = "${lab}-lava-api"
+                def retry = 3
+                while (retry--) {
+                    try {
+                        withCredentials([string(credentialsId: token,
+                                                variable: 'SECRET')]) {
+                            sh(script: """\
+kci_test \
 get_lab_info \
 --lab-config=${lab} \
 --lab-json=${lab_json} \
 --user=kernel-ci \
 --lab-token=${SECRET} \
 """)
-                            }
-                            labs.add(lab)
-                            retry = 0
-                        } catch (error) {
-                            print("Error with ${lab}: ${error}")
                         }
+                        labs.add(lab)
+                        retry = 0
+                    } catch (error) {
+                        print("Error with ${lab}: ${error}")
                     }
                 }
             }
+        }
 
-            dir(labs_info) {
-                archiveArtifacts("*.json")
-            }
+        dir(labs_info) {
+            archiveArtifacts("*.json")
         }
 
         stage("Repo") {
-            updateRepo(params.BUILD_CONFIG, kci_core, mirror, kdir, opts)
+            updateRepo(params.BUILD_CONFIG, mirror, kdir, opts)
         }
 
         if (params.ALLOW_REBUILD != true) {
@@ -397,18 +367,18 @@ get_lab_info \
         }
 
         stage("Tarball") {
-            pushTarball(params.BUILD_CONFIG, kci_core, kdir, opts)
+            pushTarball(params.BUILD_CONFIG, kdir, opts)
         }
 
         stage("Configs") {
-            listConfigs(params.BUILD_CONFIG, kci_core, kdir, configs)
+            listConfigs(params.BUILD_CONFIG, kdir, configs)
         }
 
         stage("Build") {
             def builds = [:]
             def i = 0
 
-            addBuildOpts(params.BUILD_CONFIG, kci_core, opts)
+            addBuildOpts(params.BUILD_CONFIG, opts)
 
             for (x in configs) {
                 def arch = x[0]
@@ -419,8 +389,7 @@ get_lab_info \
                 print(step_name)
 
                 builds[step_name] = buildKernelStep(
-                    "kernel-build", arch, defconfig, build_env, opts, labs,
-                    kci_core)
+                    "kernel-build", arch, defconfig, build_env, opts, labs)
 
                 i += 1
             }

--- a/jobs/build.jpl
+++ b/jobs/build.jpl
@@ -87,7 +87,7 @@ node("docker" && params.NODE_LABEL) {
     j.dockerPullWithRetry(docker_image).inside("-v $HOME/.kube:/.kube -v $HOME/.config/gcloud:/.config/gcloud -v $HOME/.azure:/.azure") {
         j.cloneKciCore(kci_core, params.KCI_CORE_URL, params.KCI_CORE_BRANCH)
         build_env_docker_image = j.dockerImageName(
-            kci_core, params.BUILD_ENVIRONMENT, params.ARCH)
+            params.BUILD_ENVIRONMENT, params.ARCH)
 
 	dir(kci_core) {
 	    stage("Init") {

--- a/jobs/build.jpl
+++ b/jobs/build.jpl
@@ -52,10 +52,6 @@ KCI_API_TOKEN_ID
   Identifier of the KernelCI backend API token stored in Jenkins
 KCI_STORAGE_URL (https://storage.kernelci.org/)
   URL of the KernelCI storage server
-KCI_CORE_URL (https://github.com/kernelci/kernelci-core.git)
-  URL of the kernelci-core repository
-KCI_CORE_BRANCH (master)
-  Name of the branch to use in the kernelci-core repository
 DOCKER_BASE (kernelci/)
   Dockerhub base address used for the build images
 PARALLEL_BUILDS
@@ -70,7 +66,6 @@ import org.kernelci.util.Job
 /* K8S build */
 node("docker" && params.NODE_LABEL) {
     def j = new Job()
-    def kci_core = "${env.WORKSPACE}/kernelci-core"
     def k8s_context = "${env.K8S_CONTEXT}"
     def docker_image = null
 
@@ -85,48 +80,52 @@ node("docker" && params.NODE_LABEL) {
 
     docker_image = "${params.DOCKER_BASE}k8s:kernelci"
     j.dockerPullWithRetry(docker_image).inside("-v $HOME/.kube:/.kube -v $HOME/.config/gcloud:/.config/gcloud -v $HOME/.azure:/.azure") {
-        j.cloneKciCore(kci_core, params.KCI_CORE_URL, params.KCI_CORE_BRANCH)
         build_env_docker_image = j.dockerImageName(
-            params.BUILD_ENVIRONMENT, params.ARCH)
+            params.BUILD_ENVIRONMENT, params.ARCH
+        )
 
-	dir(kci_core) {
-	    stage("Init") {
-		/* list clusters to init/refresh auth credentials */
-		print("K8S: Google Cloud clusters available:")
-		sh(script: "gcloud container clusters list || exit 0")
-		print("K8S: Azure clusters available:")
-		sh(script: "az aks list -o table || exit 0")
+        stage("Init") {
+            /* Remove any leftover temporary files */
+            sh(script: "rm -rf *")
+            /* list clusters to init/refresh auth credentials */
+            print("K8S: Google Cloud clusters available:")
+            sh(script: "gcloud container clusters list || exit 0")
+            print("K8S: Azure clusters available:")
+            sh(script: "az aks list -o table || exit 0")
+            print("K8S context: ${k8s_context}.  Current nodes:")
+            sh(script: "kubectl --context ${k8s_context} get nodes")
+        }
 
-		print("K8S context: ${k8s_context}.  Current nodes:")
-		sh(script: "kubectl --context ${k8s_context} get nodes")
-	    }
+        stage("Build") {
+            timeout(time: 45, unit: 'MINUTES') {
+                def k8s_job = sh(script: """\
+DOCKER_IMAGE=${build_env_docker_image} \
+/etc/kernelci/k8s/gen.py""", returnStdout: true).trim()
 
-	    stage("Build") {
-		timeout(time: 45, unit: 'MINUTES') {
-		    def k8s_job = sh(script:"DOCKER_IMAGE=${build_env_docker_image} ./config/k8s/gen.py",
-				     returnStdout: true).trim()
+                /* submit */
+                sh(script: "kubectl --context ${k8s_context} apply -f ${k8s_job}.yaml")
+                sh(script: "kubectl --context ${k8s_context} describe -f ${k8s_job}.yaml || exit 0")
 
-		    /* submit */
-		    sh(script: "kubectl --context ${k8s_context} apply -f ${k8s_job}.yaml")
-		    sh(script: "kubectl --context ${k8s_context} describe -f ${k8s_job}.yaml || exit 0")
+                /* Wait for pod to finish (will also dump logs and remove job) */
+                sh(script: """
+/etc/kernelci/k8s/wait.py \
+--context ${k8s_context} \
+--job-name ${k8s_job} \
+| tee ${k8s_job}.log""")
 
-		    /* Wait for pod to finish (will also dump logs and remove job) */
-		    sh(script: "./config/k8s/wait.py --context ${k8s_context} --job-name ${k8s_job} | tee ${k8s_job}.log")
+                /* Find upload path */
+                upload_path_line = sh(script: "grep \"^Upload path:\" ${k8s_job}.log",
+                                      returnStdout: true).trim().tokenize(':')
+                if (upload_path_line.size() > 0) {
+                    upload_path = upload_path_line[1].trim()
+                    print("Upload path: ${upload_path}")
 
-		    /* Find upload path */
-		    upload_path_line = sh(script: "grep \"^Upload path:\" ${k8s_job}.log",
-					  returnStdout: true).trim().tokenize(':')
-		    if (upload_path_line.size() > 0) {
-			upload_path = upload_path_line[1].trim()
-			print("Upload path: ${upload_path}")
-
-			sh(script: "wget -q ${KCI_STORAGE_URL}/${upload_path}/bmeta.json")
-			sh(script: "wget -q ${KCI_STORAGE_URL}/${upload_path}/steps.json")
-			sh(script: "wget -q ${KCI_STORAGE_URL}/${upload_path}/artifacts.json")
-			archiveArtifacts("*.json")
-		    }
-		}
-	    }
-	}
+                    sh(script: "wget -q ${KCI_STORAGE_URL}/${upload_path}/bmeta.json")
+                    sh(script: "wget -q ${KCI_STORAGE_URL}/${upload_path}/steps.json")
+                    sh(script: "wget -q ${KCI_STORAGE_URL}/${upload_path}/artifacts.json")
+                    archiveArtifacts("*.json")
+                }
+            }
+        }
     }
 }

--- a/jobs/monitor.jpl
+++ b/jobs/monitor.jpl
@@ -33,10 +33,6 @@ KCI_API_TOKEN_ID
   Identifier of the KernelCI backend API token stored in Jenkins
 KCI_STORAGE_URL (https://storage.kernelci.org/)
   URL of the KernelCI storage server
-KCI_CORE_URL (https://github.com/kernelci/kernelci-core.git)
-  URL of the kernelci-core repository
-KCI_CORE_BRANCH (master)
-  Name of the branch to use in the kernelci-core repository
 DOCKER_BASE (kernelci/)
   Dockerhub base address used for the build images
 */
@@ -44,45 +40,41 @@ DOCKER_BASE (kernelci/)
 @Library('kernelci') _
 import org.kernelci.util.Job
 
-def updateLastCommit(config, commit, kci_core) {
-    dir(kci_core) {
-        withCredentials([string(credentialsId: params.KCI_API_TOKEN_ID,
-                                variable: 'SECRET')]) {
-            sh(script: """\
-./kci_build \
+def updateLastCommit(config, commit) {
+    withCredentials([string(credentialsId: params.KCI_API_TOKEN_ID,
+                            variable: 'SECRET')]) {
+        sh(script: """\
+kci_build \
 update_last_commit \
 --build-config=${config} \
 --commit=${commit} \
 --api=${params.KCI_API_URL} \
 --db-token=${SECRET} \
 """)
-        }
     }
 }
 
-def checkConfig(config, kci_core) {
+def checkConfig(config) {
     def retry = 3
     def commit = null
 
-    dir(kci_core) {
-        while (retry--) {
-            try {
-                commit = sh(
-                    script: """
-./kci_build \
+    while (retry--) {
+        try {
+            commit = sh(
+                script: """
+kci_build \
 check_new_commit \
 --build-config=${config} \
 --storage=${params.KCI_STORAGE_URL} \
 """, returnStdout: true).trim()
-                retry = 0
-            } catch (error) {
+            retry = 0
+        } catch (error) {
 
-                if (retry) {
-                    print("Failed to check ${config}, retyring: ${error}")
-                    sleep(1)
-                } else {
-                    print("ERROR: All attempts failed with ${config}")
-                }
+            if (retry) {
+                print("Failed to check ${config}, retyring: ${error}")
+                sleep(1)
+            } else {
+                print("ERROR: All attempts failed with ${config}")
             }
         }
     }
@@ -94,7 +86,7 @@ check_new_commit \
 
     print("${config}: triggering build")
 
-    updateLastCommit(config, commit, kci_core)
+    updateLastCommit(config, commit)
 
     def job = "kernel-build-trigger"
     def str_params = [
@@ -110,7 +102,6 @@ check_new_commit \
 
 node("docker && monitor") {
     def j = new Job()
-    def kci_core = env.WORKSPACE + '/kernelci-core'
     def docker_image = "${params.DOCKER_BASE}kernelci"
 
     print("""\
@@ -118,35 +109,26 @@ node("docker && monitor") {
     Container: ${docker_image}""")
 
     j.dockerPullWithRetry(docker_image).inside() {
-        stage("Init") {
-            timeout(time: 15, unit: 'MINUTES') {
-                j.cloneKciCore(
-                    kci_core, params.KCI_CORE_URL, params.KCI_CORE_BRANCH)
-            }
-        }
-
         stage("Monitor") {
-            dir(kci_core) {
-                def config_list = null
-                def config_jobs = [:]
+            def config_list = null
+            def config_jobs = [:]
 
-                if (params.CONFIG_LIST != "") {
-                    config_list = params.CONFIG_LIST.tokenize(' ')
-                } else {
-                    def raw_configs = sh(script: "./kci_build list_configs",
-                                         returnStdout: true).trim()
-                    config_list = raw_configs.tokenize('\n')
-                }
-
-                for (String config: config_list) {
-                    def config_name = config
-                    config_jobs[config_name] = {
-                        checkConfig(config_name, kci_core)
-                    }
-                }
-
-                parallel(config_jobs)
+            if (params.CONFIG_LIST != "") {
+                config_list = params.CONFIG_LIST.tokenize(' ')
+            } else {
+                def raw_configs = sh(script: "kci_build list_configs",
+                                     returnStdout: true).trim()
+                config_list = raw_configs.tokenize('\n')
             }
+
+            for (String config: config_list) {
+                def config_name = config
+                config_jobs[config_name] = {
+                    checkConfig(config_name)
+                }
+            }
+
+            parallel(config_jobs)
         }
     }
 }

--- a/jobs/test-runner.jpl
+++ b/jobs/test-runner.jpl
@@ -32,10 +32,6 @@ BUILD_JOB_NAME
   Name of the job that built the kernel
 BUILD_JOB_NUMBER
   Number of the job that built the kernel
-KCI_CORE_URL (https://github.com/kernelci/kernelci-core.git)
-  URL of the kernelci-core repository
-KCI_CORE_BRANCH (master)
-  Name of the branch to use in the kernelci-core repository
 KCI_STORAGE_URL (https://storage.kernelci.org/)
   URL of the KernelCI storage server
 DOCKER_BASE (kernelci/)
@@ -66,14 +62,13 @@ def getArtifacts(artifacts)
     }
 }
 
-def generateJobs(kci_core, lab, artifacts, jobs_dir)
+def generateJobs(lab, artifacts, jobs_dir)
 {
     def token = "${lab}-lava-api"
 
-    dir(kci_core) {
-        withCredentials([string(credentialsId: token, variable: 'SECRET')]) {
-            sh(script: """\
-./kci_test \
+    withCredentials([string(credentialsId: token, variable: 'SECRET')]) {
+        sh(script: """\
+kci_test \
 generate \
 --install-path=${artifacts} \
 --lab-json=${artifacts}/${lab}.json \
@@ -85,31 +80,27 @@ generate \
 --callback-id=${params.CALLBACK_ID} \
 --callback-url=${params.CALLBACK_URL} \
 """)
-        }
     }
 }
 
-def submitJobs(kci_core, lab, jobs_dir)
+def submitJobs(lab, jobs_dir)
 {
     def token = "${lab}-lava-api"
 
-    dir(kci_core) {
-        withCredentials([string(credentialsId: token, variable: 'SECRET')]) {
-            sh(script: """\
-./kci_test \
+    withCredentials([string(credentialsId: token, variable: 'SECRET')]) {
+        sh(script: """\
+kci_test \
 submit \
 --lab-config=${lab} \
 --user=kernel-ci \
 --lab-token=${SECRET} \
 --jobs=${jobs_dir}/* \
 """)
-        }
     }
 }
 
 node("docker && test-runner") {
     def j = new Job()
-    def kci_core = "${env.WORKSPACE}/kernelci-core"
     def jobs_dir = "${env.WORKSPACE}/jobs"
     def artifacts = "${env.WORKSPACE}/artifacts"
     def docker_image = "${params.DOCKER_BASE}kernelci"
@@ -126,16 +117,7 @@ node("docker && test-runner") {
             sh(script: "rm -rf ${jobs_dir}")
 
             timeout(time: 15, unit: 'MINUTES') {
-                parallel(
-                    kci_core: {
-                        j.cloneKciCore(
-                            kci_core,
-                            params.KCI_CORE_URL, params.KCI_CORE_BRANCH)
-                    },
-                    artifacts: {
-                        getArtifacts(artifacts)
-                    },
-                )
+                getArtifacts(artifacts)
             }
 
             print("Artifacts:")
@@ -148,7 +130,7 @@ node("docker && test-runner") {
         stage("Generate") {
             for (lab in labs) {
                 def lab_dir = "${jobs_dir}/${lab}"
-                generateJobs(kci_core, lab, artifacts, lab_dir)
+                generateJobs(lab, artifacts, lab_dir)
                 labs_submit.add(lab)
             }
         }
@@ -165,7 +147,7 @@ node("docker && test-runner") {
                 print(step_name)
 
                 steps[step_name] = {
-                    submitJobs(kci_core, lab_name, lab_dir)
+                    submitJobs(lab_name, lab_dir)
                 }
 
                 i += 1

--- a/src/org/kernelci/util/Job.groovy
+++ b/src/org/kernelci/util/Job.groovy
@@ -43,27 +43,25 @@ def cloneKciCore(path, url, branch) {
     }
 }
 
-def dockerImageName(kci_core, build_env, kernel_arch) {
+def dockerImageName(build_env, kernel_arch) {
     def image_name = build_env
 
-    dir(kci_core) {
-        def build_env_raw = sh(
-            script: """
-./kci_build \
+    def build_env_raw = sh(
+        script: """
+kci_build \
   show_build_env \
   --build-env=${build_env} \
   --arch=${kernel_arch} \
 """, returnStdout: true).trim()
-        def build_env_data = build_env_raw.split('\n').toList()
-        def cc_arch = build_env_data[3]
+    def build_env_data = build_env_raw.split('\n').toList()
+    def cc_arch = build_env_data[3]
 
-        if (cc_arch == 'sparc') /* No kselftest variant for sparc */
-            image_name = "${build_env}:${cc_arch}-kernelci"
-        else if (cc_arch)
-            image_name = "${build_env}:${cc_arch}-kselftest-kernelci"
-        else
-            image_name = "${build_env}:kselftest-kernelci"
-    }
+    if (cc_arch == 'sparc') /* No kselftest variant for sparc */
+        image_name = "${build_env}:${cc_arch}-kernelci"
+    else if (cc_arch)
+        image_name = "${build_env}:${cc_arch}-kselftest-kernelci"
+    else
+        image_name = "${build_env}:kselftest-kernelci"
 
     return image_name
 }


### PR DESCRIPTION
Rather than doing git clones, use the `kernelci` Python package already installed in the Docker image.