### PR TITLE
jobs/bisect.jpl: Add fetch firmware step to bisection

### DIFF
--- a/jobs/bisect.jpl
+++ b/jobs/bisect.jpl
@@ -268,6 +268,14 @@ make_config \
 
         sh(script: """\
 ./kci_build \
+fetch_firmware \
+--kdir=${kdir} \
+--output=${output} \
+--install \
+""")
+
+        sh(script: """\
+./kci_build \
 make_kernel \
 --kdir=${kdir} \
 --output=${output} \


### PR DESCRIPTION
As discovered by @gtucker, bisection job missing step to fetch firmware:
```
make[5]: *** No rule to make target '/lib/firmware/amdgpu/stoney_ce.bin', needed by 'drivers/base/firmware_loader/builtin/amdgpu/stoney_ce.bin.gen.o'.  Stop.
```
This patch add necessary command to jenkins definition.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>