### PR TITLE
CHROMEOS rootfs-builder.jpl: Update rootfs builder for kci_docker

### DIFF
--- a/jobs/rootfs-append-cros-image.jpl
+++ b/jobs/rootfs-append-cros-image.jpl
@@ -1,0 +1,97 @@
+#!/usr/bin/env groovy
+
+/*
+  Copyright (C) 2022 Collabora Limited
+  Author: Michal Galka <michal.galka@collabora.com>
+
+  This module is free software; you can redistribute it and/or modify it under
+  the terms of the GNU Lesser General Public License as published by the Free
+  Software Foundation; either version 2.1 of the License, or (at your option)
+  any later version.
+
+  This library is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+  details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with this library; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+/* ----------------------------------------------------------------------------
+ * Jenkins parameters
+
+DOCKER_BASE
+  Dockerhub base address used for the build images
+FLASH_ROOTFS_STORAGE_URL (https://storage.kernelci.org/images/rootfs)
+  Rootfs storage URL
+FLASH_ROOTFS_CONFIG
+  Configuration name to build rootfs images
+FLASH_ROOTFS_ARCH
+  Flashing rootfs image architecture
+FLASH_PIPELINE_VERSION
+  Unique string identifier for the series of rootfs build jobs
+CROS_ROOTFS_STORAGE_URL (https://storage.chromeos.kernelci.org/images/rootfs)
+  Chrome OS images storage URL
+CROS_CONFIG
+  Configuration name used to build Chrome OS
+CROS_ARCH
+  Chrome OS architecture
+CROS_PIPELINE_VERSION
+  Unique string identifier for the series of Chrome OS build jobs
+*/
+
+@Library('kernelci') _
+import org.kernelci.util.Job
+
+node("debos && docker") {
+    def j = new Job()
+    def cros_image_name = "chromiumos_test_image.bin"
+    def flash_image_name = "full.rootfs.tar"
+    def docker_image = "${params.DOCKER_BASE}cros-sdk"
+    def cros_image_url = "${params.CROS_ROOTFS_STORAGE_URL}/chromeos/${params.CROS_CONFIG}/${params.CROS_PIPELINE_VERSION}/${params.CROS_ARCH}/${cros_image_name}.gz"
+    def flash_image_url = "${params.FLASH_ROOTFS_STORAGE_URL}/debian/${params.FLASH_ROOTFS_CONFIG}/${params.FLASH_PIPELINE_VERSION}/${params.FLASH_ROOTFS_ARCH}/${flash_image_name}.xz"
+    def upload_path = "chromeos/${params.CROS_CONFIG}/${params.CROS_PIPELINE_VERSION}/${params.CROS_ARCH}"
+    def output_image_name = "full-cros-flash.tar.gz"
+
+    print("""\
+    CrOS image URL:    ${cros_image_url}
+    Flash image URL:   ${flash_image_url}
+    Upload path:       ${upload_path}
+    Docker:            ${docker_image}""")
+
+    j.dockerPullWithRetry(docker_image).inside() {
+        stage("Download") {
+          sh(script: """\
+wget -O ${cros_image_name}.gz ${cros_image_url}
+wget -O ${flash_image_name}.xz ${flash_image_url}"""
+          )
+        }
+        stage("Append") {
+          sh(script: """\
+gunzip -f ${cros_image_name}.gz
+mkdir -p ./root
+mv ${cros_image_name} ./root/
+xz -fd ${flash_image_name}.xz
+tar rvf ${flash_image_name} ./root/${cros_image_name}
+gzip -f ${flash_image_name}
+mv ${flash_image_name}.gz ${output_image_name}
+          """
+          )
+        }
+        stage("Upload") {
+            sshagent(credentials : ['jenkins-chromeos-storage-private-key']) {
+                sh(script: """\
+scp \
+-o StrictHostKeyChecking=no \
+-P 22022 \
+${output_image_name} \
+chromeos@storage.chromeos.kernelci.org:\
+~/images/rootfs/chromeos/${params.CROS_CONFIG}/${params.CROS_PIPELINE_VERSION}/${params.CROS_ARCH}/
+"""
+                  )
+            }
+        }
+    }
+}

--- a/jobs/rootfs-builder.jpl
+++ b/jobs/rootfs-builder.jpl
@@ -126,8 +126,24 @@ node("debos && docker") {
         }
 
         stage("Upload") {
-            timeout(time: 30, unit: 'MINUTES') {
-                upload(config, pipeline_version, kci_core, rootfs_type, arch);
+            sshagent(credentials : ['jenkins-chromeos-storage-private-key']) {
+                sh(script: """\
+ssh \
+-o StrictHostKeyChecking=no \
+-p 22022 \
+chromeos@storage.chromeos.kernelci.org 'mkdir -p ~/images/rootfs/chromeos/${pipeline_version} || true'
+"""
+                  )
+                sh(script: """\
+scp \
+-o StrictHostKeyChecking=no \
+-P 22022 \
+-r \
+kernelci-core/${pipeline_version}/_install_/* \
+chromeos@storage.chromeos.kernelci.org:\
+~/images/rootfs/chromeos/${pipeline_version}
+"""
+                  )
             }
         }
     }

--- a/jobs/rootfs-builder.jpl
+++ b/jobs/rootfs-builder.jpl
@@ -102,6 +102,10 @@ node("debos && docker") {
     def rootfs_type = "${params.ROOTFS_TYPE}"
     def docker_image = "${params.DOCKER_BASE}${rootfs_type}:kernelci"
 
+    if (rootfs_type == "chromiumos") {
+        docker_image = "kernelci/cros-sdk"
+    }
+
     print("""\
     Config:    ${config}
     CPU arch:  ${arch}

--- a/jobs/rootfs-builder.jpl
+++ b/jobs/rootfs-builder.jpl
@@ -48,6 +48,15 @@ import org.kernelci.util.Job
 
 def build(config, arch, pipeline_version, kci_core, rootfs_type) {
     dir(kci_core) {
+/*
+   Diagnostic commands to troubleshoot ChromiumOS SDK failures
+   id is expected to be 996
+   id after sudo expected to be root (to check if sudo works)
+   df -h to check disk space, as SDK require around 200GB free space
+*/
+        sh 'id'
+        sh 'sudo id'
+        sh 'df -h'
         sh(script: """\
 ./kci_rootfs \
 build \

--- a/jobs/rootfs-builder.jpl
+++ b/jobs/rootfs-builder.jpl
@@ -126,9 +126,7 @@ node("debos && docker") {
         inside(" --privileged --device /dev/kvm -v /dev:/dev") {
 
         stage("Build") {
-            timeout(time: 20, unit: 'HOURS') {
-	        build(config, arch, pipeline_version, kci_core, rootfs_type)
-            }
+	    build(config, arch, pipeline_version, kci_core, rootfs_type)
         }
 
         stage("Upload") {

--- a/jobs/rootfs-builder.jpl
+++ b/jobs/rootfs-builder.jpl
@@ -54,9 +54,11 @@ def build(config, arch, pipeline_version, kci_core, rootfs_type) {
    id after sudo expected to be root (to check if sudo works)
    df -h to check disk space, as SDK require around 200GB free space
 */
-        sh 'id'
-        sh 'sudo id'
-        sh 'df -h'
+        if (rootfs_type == "chromiumos") {
+           sh 'id'
+           sh 'sudo id'
+           sh 'df -h'
+        }
         sh(script: """\
 ./kci_rootfs \
 build \

--- a/jobs/rootfs-builder.jpl
+++ b/jobs/rootfs-builder.jpl
@@ -48,17 +48,19 @@ import org.kernelci.util.Job
 
 def build(config, arch, pipeline_version, kci_core, rootfs_type) {
     dir(kci_core) {
-/*
-   Diagnostic commands to troubleshoot ChromiumOS SDK failures
-   id is expected to be 996
-   id after sudo expected to be root (to check if sudo works)
-   df -h to check disk space, as SDK require around 200GB free space
-*/
+
+        /*
+          Diagnostic commands to troubleshoot ChromiumOS SDK failures
+          id is expected to be 996
+          id after sudo expected to be root (to check if sudo works)
+          df -h to check disk space, as SDK require around 200GB free space
+        */
         if (rootfs_type == "chromiumos") {
            sh 'id'
            sh 'sudo id'
            sh 'df -h'
         }
+
         sh(script: """\
 ./kci_rootfs \
 build \
@@ -130,20 +132,21 @@ node("debos && docker") {
         }
 
         stage("Upload") {
-          def rootfs_type_dir = ""
+            def rootfs_type_dir = ""
 
-          switch(rootfs_type) {
+            switch(rootfs_type) {
             case 'debos':
-              rootfs_type_dir = 'debian'
-              break
+                rootfs_type_dir = 'debian'
+                break
 
             case 'chromiumos':
-              rootfs_type_dir = 'chromeos'
-              break
+                rootfs_type_dir = 'chromeos'
+                break
 
             default:
-              rootfs_type_dir = rootfs_type
-          }
+                rootfs_type_dir = rootfs_type
+            }
+
             sshagent(credentials : ['jenkins-chromeos-storage-private-key']) {
                 sh(script: """\
 ssh \
@@ -164,5 +167,5 @@ chromeos@storage.chromeos.kernelci.org:\
                   )
             }
         }
-    }
+        }
 }

--- a/jobs/rootfs-builder.jpl
+++ b/jobs/rootfs-builder.jpl
@@ -128,12 +128,26 @@ node("debos && docker") {
         }
 
         stage("Upload") {
+          def rootfs_type_dir = ""
+
+          switch(rootfs_type) {
+            case 'debos':
+              rootfs_type_dir = 'debian'
+              break
+
+            case 'chromiumos':
+              rootfs_type_dir = 'chromeos'
+              break
+
+            default:
+              rootfs_type_dir = rootfs_type
+          }
             sshagent(credentials : ['jenkins-chromeos-storage-private-key']) {
                 sh(script: """\
 ssh \
 -o StrictHostKeyChecking=no \
 -p 22022 \
-chromeos@storage.chromeos.kernelci.org 'mkdir -p ~/images/rootfs/chromeos/${pipeline_version} || true'
+chromeos@storage.chromeos.kernelci.org 'mkdir -p ~/images/rootfs/${rootfs_type_dir}/${config}/${pipeline_version} || true'
 """
                   )
                 sh(script: """\
@@ -141,9 +155,9 @@ scp \
 -o StrictHostKeyChecking=no \
 -P 22022 \
 -r \
-kernelci-core/${pipeline_version}/_install_/* \
+kernelci-core/${pipeline_version}/_install_/${config}/* \
 chromeos@storage.chromeos.kernelci.org:\
-~/images/rootfs/chromeos/${pipeline_version}
+~/images/rootfs/${rootfs_type_dir}/${config}/${pipeline_version}
 """
                   )
             }

--- a/jobs/rootfs-builder.jpl
+++ b/jobs/rootfs-builder.jpl
@@ -108,7 +108,7 @@ node("debos && docker") {
     }
 
     j.dockerPullWithRetry(docker_image).
-        inside(" --privileged --device /dev/kvm ") {
+        inside(" --privileged --device /dev/kvm -v /dev:/dev") {
 
         stage("Build") {
             timeout(time: 8, unit: 'HOURS') {

--- a/jobs/rootfs-builder.jpl
+++ b/jobs/rootfs-builder.jpl
@@ -47,29 +47,26 @@ PIPELINE_VERSION
 import org.kernelci.util.Job
 
 def build(config, arch, pipeline_version, kci_core, rootfs_type) {
-    dir(kci_core) {
+    /*
+      Diagnostic commands to troubleshoot ChromiumOS SDK failures
+      id is expected to be 996
+      id after sudo expected to be root (to check if sudo works)
+      df -h to check disk space, as SDK require around 200GB free space
+    */
+    if (rootfs_type == "chromiumos") {
+       sh 'id'
+       sh 'sudo id'
+       sh 'df -h'
+    }
 
-        /*
-          Diagnostic commands to troubleshoot ChromiumOS SDK failures
-          id is expected to be 996
-          id after sudo expected to be root (to check if sudo works)
-          df -h to check disk space, as SDK require around 200GB free space
-        */
-        if (rootfs_type == "chromiumos") {
-           sh 'id'
-           sh 'sudo id'
-           sh 'df -h'
-        }
-
-        sh(script: """\
-./kci_rootfs \
+    sh(script: """\
+kci_rootfs \
 build \
 --rootfs-config ${config} \
 --arch ${arch} \
---data-path config/rootfs/${rootfs_type} \
+--data-path /etc/kernelci/rootfs/${rootfs_type} \
 --output ${pipeline_version}
 """)
-    }
 }
 
 def upload(config, pipeline_version, kci_core, rootfs_type, arch) {
@@ -80,8 +77,7 @@ def upload(config, pipeline_version, kci_core, rootfs_type, arch) {
        rootfs_upload_path = "images/rootfs/buildroot/${config}/${pipeline_version}"
     }
 
-    dir(kci_core) {
-        withCredentials([string(credentialsId: params.KCI_API_TOKEN_ID,
+    withCredentials([string(credentialsId: params.KCI_API_TOKEN_ID,
                                 variable: 'API_TOKEN')]) {
             sh(script: """\
 ./kci_rootfs \
@@ -91,8 +87,8 @@ upload \
 --rootfs-dir ${pipeline_version}/_install_/${config} \
 --upload-path ${rootfs_upload_path}
 """)
-        }
     }
+
 }
 
 node("debos && docker") {
@@ -105,7 +101,7 @@ node("debos && docker") {
     def docker_image = "${params.DOCKER_BASE}${rootfs_type}:kernelci"
 
     if (rootfs_type == "chromiumos") {
-        docker_image = "kernelci/cros-sdk"
+        docker_image = "${params.DOCKER_BASE}sdk:kernelci"
     }
 
     print("""\
@@ -118,10 +114,6 @@ node("debos && docker") {
         print("Invalid parameters")
         currentBuild.result = 'ABORTED'
         return
-    }
-
-    j.dockerPullWithRetry(docker_image).inside() {
-        j.cloneKciCore(kci_core, params.KCI_CORE_URL, params.KCI_CORE_BRANCH)
     }
 
     j.dockerPullWithRetry(docker_image).
@@ -160,7 +152,7 @@ scp \
 -o StrictHostKeyChecking=no \
 -P 22022 \
 -r \
-kernelci-core/${pipeline_version}/_install_/${config}/* \
+${pipeline_version}/_install_/${config}/* \
 chromeos@storage.chromeos.kernelci.org:\
 ~/images/rootfs/${rootfs_type_dir}/${config}/${pipeline_version}
 """

--- a/jobs/rootfs-builder.jpl
+++ b/jobs/rootfs-builder.jpl
@@ -122,7 +122,7 @@ node("debos && docker") {
         inside(" --privileged --device /dev/kvm -v /dev:/dev") {
 
         stage("Build") {
-            timeout(time: 8, unit: 'HOURS') {
+            timeout(time: 20, unit: 'HOURS') {
 	        build(config, arch, pipeline_version, kci_core, rootfs_type)
             }
         }


### PR DESCRIPTION
As new kci_docker images include kernelci-core tools, we dont need anymore git clone it and do relevant steps. Also we need to update, to use configuration files at /etc/kernelci

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>