### PR TITLE
build.jpl: Improve reliability of build process

### DIFF
--- a/jobs/build.jpl
+++ b/jobs/build.jpl
@@ -79,21 +79,28 @@ node("docker" && params.NODE_LABEL) {
     K8S ctx:   ${k8s_context}""")
 
     docker_image = "${params.DOCKER_BASE}k8s:kernelci"
-    j.dockerPullWithRetry(docker_image).inside("-v $HOME/.kube:/.kube -v $HOME/.config/gcloud:/.config/gcloud -v $HOME/.azure:/.azure") {
+    j.dockerPullWithRetry(docker_image).inside("-v $HOME/.kube:/.kube-host:ro -v $HOME/.config/gcloud:/.config/gcloud -v $HOME/.azure:/.azure") {
         build_env_docker_image = j.dockerImageName(
             params.BUILD_ENVIRONMENT, params.ARCH
         )
+        env.KUBECONFIG="/tmp/.kube/config"
 
         stage("Init") {
-            /* Remove any leftover temporary files */
+            /* Remove old bmeta.json and etc, as jenkins make workspace persistent, even it is not mapped as volume in docker */
             sh(script: "rm -rf *")
+            /* Copy host kubernetes configs */
+            sh(script: "mkdir /tmp/.kube")
+            sh(script: "cp -r /.kube-host/* /tmp/.kube")
             /* list clusters to init/refresh auth credentials */
             print("K8S: Google Cloud clusters available:")
+            /* Following commands are informational,
+               not critical for the job, so return code can be ignored
+            */
             sh(script: "gcloud container clusters list || exit 0")
             print("K8S: Azure clusters available:")
             sh(script: "az aks list -o table || exit 0")
             print("K8S context: ${k8s_context}.  Current nodes:")
-            sh(script: "kubectl --context ${k8s_context} get nodes")
+            sh(script: "kubectl --context ${k8s_context} get nodes || exit 0")
         }
 
         stage("Build") {


### PR DESCRIPTION
Several steps to improve job run reliability:
1)kubectl get nodes are not critical for process and should not cause job termination, ignore exit code. This happen often.
2)Make .kube configuration file mount as read only, as this volume is shared by multiple processed and getting corrupted. 
3)Do not run "rm -rf *" as we are supposed to run in new docker image.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>