### PR TITLE
T37847 multiple rootfs and archs

### DIFF
--- a/jobs.groovy
+++ b/jobs.groovy
@@ -240,8 +240,8 @@ pipelineJob('rootfs-build-trigger') {
     stringParam('KCI_CORE_BRANCH', KCI_CORE_BRANCH, 'Name of the branch to use in the kernelci-core repository.')
     stringParam('DOCKER_BASE', KCI_DOCKER_BASE, 'Dockerhub base address used for the rootfs build images.')
     stringParam('ROOTFS_CONFIG','','Name of the rootfs configuration, all rootfs will be built by default. Cannot be used with ROOTFS_TYPE')
-    stringParam('ROOTFS_ARCH','','Name of the rootfs arch config, all given arch will be built by default.')
-    stringParam('ROOTFS_TYPE','','Name of the rootfs type config, all types will be built by default. Cannot be used with ROOTFS_CONFIG')
+    stringParam('ROOTFS_ARCH','','List of the rootfs arch configs, all given archs will be built by default.')
+    stringParam('ROOTFS_TYPE','','List of the rootfs type config, all types will be built by default. Cannot be used with ROOTFS_CONFIG')
     stringParam('PIPELINE_VERSION','','Unique string identifier for the series of rootfs build jobs.')
   }
 }

--- a/jobs/rootfs-trigger.jpl
+++ b/jobs/rootfs-trigger.jpl
@@ -44,18 +44,19 @@ PIPELINE_VERSION
 @Library('kernelci') _
 import org.kernelci.util.Job
 
-def listVariants(kci_core, config_list, rootfs_config, rootfs_arch, rootfs_type) {
+def listVariants(kci_core, config_list, rootfs_config, rootfs_arch_list, rootfs_type_list) {
     def cli_opts = ' '
 
     if (rootfs_config) {
+
         cli_opts += " --rootfs-config ${rootfs_config}"
     }
 
-    if (rootfs_arch) {
+    for (String rootfs_arch: rootfs_arch_list) {
         cli_opts += " --arch ${rootfs_arch}"
     }
 
-    if (rootfs_type) {
+    for (String rootfs_type: rootfs_type_list) {
         cli_opts += " --rootfs-type ${rootfs_type}"
     }
 
@@ -129,8 +130,10 @@ node("docker && rootfs-trigger") {
         }
 
         stage("Configs") {
+            def rootfs_type_list = params.ROOTFS_TYPE.tokenize(' ')
+            def rootfs_arch_list = params.ROOTFS_ARCH.tokenize(' ')
             listVariants(kci_core, configs, params.ROOTFS_CONFIG,
-                         params.ROOTFS_ARCH, params.ROOTFS_TYPE)
+                         rootfs_arch_list, rootfs_type_list)
         }
 
         stage("Build") {


### PR DESCRIPTION
rootfs_trigger.jpl:
Add parsing of space separated lists of rootfs architecture names and rootfs types.

jobs.groovy: rootfs-build-trigger description adjustments

Adjust parameters description to match with the current implementation accepting lists of rootfs types and architectures.

Depends on: https://github.com/kernelci/kernelci-core/pull/1445