### PR TITLE
build.jpl: Copy only necessary config file

### DIFF
--- a/jobs/build.jpl
+++ b/jobs/build.jpl
@@ -90,7 +90,7 @@ node("docker" && params.NODE_LABEL) {
             sh(script: "rm -rf *")
             /* Copy host kubernetes configs */
             sh(script: "mkdir /tmp/.kube")
-            sh(script: "cp -r /.kube-host/* /tmp/.kube")
+            sh(script: "cp -r /.kube-host/config /tmp/.kube")
             /* list clusters to init/refresh auth credentials */
             print("K8S: Google Cloud clusters available:")
             /* Following commands are informational,


### PR DESCRIPTION
Kubernetes config directory might contain temporary files, that might not be copied or disappear during copy. It is more safe to copy only necessary file, otherwise error might appear:
```
+ cp -r /.kube-host/cache /.kube-host/config /.kube-host/http-cache /tmp/.kube
cp: cannot stat '/.kube-host/cache/http/ec5ba2e85e057052ea061fcd28378a2094b832d5f9168e43cb599b8f5fbfb0b7': No such file or directory
```

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>