### PR TITLE
*.jpl: Add --init flag for image.inside()

### DIFF
--- a/jobs/bisect.jpl
+++ b/jobs/bisect.jpl
@@ -769,13 +769,13 @@ ${params_summary}""")
         }
     }
 
-    j.dockerPullWithRetry("${params.DOCKER_BASE}kernelci").inside() {
+    j.dockerPullWithRetry("${params.DOCKER_BASE}kernelci").inside('--init') {
         build_env_docker_image = j.dockerImageName(
             params.BUILD_ENVIRONMENT, params.ARCH)
         docker_image = "${params.DOCKER_BASE}${build_env_docker_image}"
     }
 
-    j.dockerPullWithRetry(docker_image).inside() {
+    j.dockerPullWithRetry(docker_image).inside('--init') {
         try {
             def valid_bisect = bisection(kdir, checks)
             if (!valid_bisect)

--- a/jobs/build-trigger.jpl
+++ b/jobs/build-trigger.jpl
@@ -303,7 +303,7 @@ node("docker && build-trigger") {
     Commit:    ${params.COMMIT_ID}
     Container: ${docker_image}""")
 
-    j.dockerPullWithRetry(docker_image).inside() {
+    j.dockerPullWithRetry(docker_image).inside('--init') {
         def labs = []
 
         stage("Labs") {

--- a/jobs/build.jpl
+++ b/jobs/build.jpl
@@ -79,7 +79,7 @@ node("docker" && params.NODE_LABEL) {
     K8S ctx:   ${k8s_context}""")
 
     docker_image = "${params.DOCKER_BASE}k8s:kernelci"
-    j.dockerPullWithRetry(docker_image).inside("-v $HOME/.kube:/.kube-host:ro -v $HOME/.config/gcloud:/.config/gcloud -v $HOME/.azure:/.azure") {
+    j.dockerPullWithRetry(docker_image).inside("--init -v $HOME/.kube:/.kube-host:ro -v $HOME/.config/gcloud:/.config/gcloud -v $HOME/.azure:/.azure") {
         build_env_docker_image = j.dockerImageName(
             params.BUILD_ENVIRONMENT, params.ARCH
         )

--- a/jobs/monitor.jpl
+++ b/jobs/monitor.jpl
@@ -108,7 +108,7 @@ node("docker && monitor") {
     Storage:   ${params.KCI_STORAGE_URL}
     Container: ${docker_image}""")
 
-    j.dockerPullWithRetry(docker_image).inside() {
+    j.dockerPullWithRetry(docker_image).inside('--init') {
         stage("Monitor") {
             def config_list = null
             def config_jobs = [:]

--- a/jobs/rootfs-builder.jpl
+++ b/jobs/rootfs-builder.jpl
@@ -103,12 +103,12 @@ node("debos && docker") {
         return
     }
 
-    j.dockerPullWithRetry(docker_image).inside() {
+    j.dockerPullWithRetry(docker_image).inside('--init') {
         j.cloneKciCore(kci_core, params.KCI_CORE_URL, params.KCI_CORE_BRANCH)
     }
 
     j.dockerPullWithRetry(docker_image).
-        inside(" --privileged --device /dev/kvm ") {
+        inside(" --privileged --device /dev/kvm --init ") {
 
         stage("Build") {
             timeout(time: 8, unit: 'HOURS') {

--- a/jobs/rootfs-trigger.jpl
+++ b/jobs/rootfs-trigger.jpl
@@ -120,7 +120,7 @@ node("docker && rootfs-trigger") {
     Rootfs type: ${params.ROOTFS_TYPE}
     Container:   ${docker_image}""")
 
-    j.dockerPullWithRetry(docker_image).inside() {
+    j.dockerPullWithRetry(docker_image).inside('--init') {
 
         stage("Init") {
             timeout(time: 15, unit: 'MINUTES') {

--- a/jobs/test-runner.jpl
+++ b/jobs/test-runner.jpl
@@ -111,7 +111,7 @@ node("docker && test-runner") {
     Labs:      ${params.LABS}
     Container: ${docker_image}""")
 
-    j.dockerPullWithRetry(docker_image).inside() {
+    j.dockerPullWithRetry(docker_image).inside('--init') {
         stage("Init") {
             sh(script: "rm -rf ${artifacts}")
             sh(script: "rm -rf ${jobs_dir}")


### PR DESCRIPTION
As explained in https://issues.jenkins.io/browse/JENKINS-45888, to solve problems with zombies we need to add --init flag for docker image.

Fixes https://github.com/kernelci/kernelci-core/issues/1499

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>