### PR TITLE
jobs/monitor.jpl: print commit number when triggering build

### DIFF
--- a/jobs/monitor.jpl
+++ b/jobs/monitor.jpl
@@ -84,7 +84,7 @@ check_new_commit \
         return
     }
 
-    print("${config}: triggering build")
+    print("${config}: triggering build with commit ${commit}")
 
     updateLastCommit(config, commit)
 


### PR DESCRIPTION
Print the commit number used when triggering a new build.  This helps keeping track of what the job is doing and diagnose issues when it fails.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>