### PR TITLE
bisect.jpl: use kci_build --storage-config

### DIFF
--- a/jobs.groovy
+++ b/jobs.groovy
@@ -339,6 +339,7 @@ pipelineJob('lava-bisection') {
     stringParam('KCI_API_URL', KCI_API_URL, 'URL of the KernelCI back-end API.')
     stringParam('KCI_API_TOKEN_ID', KCI_API_TOKEN_ID, 'Identifier of the KernelCI backend API token stored in Jenkins.')
     stringParam('KCI_STORAGE_URL', KCI_STORAGE_URL, 'URL of the KernelCI storage server.')
+    stringParam('KCI_STORAGE_CONFIG', KCI_STORAGE_CONFIG, 'Name of the KernelCI storage configuration.')
     stringParam('KCI_DB_CONFIG', KCI_DB_CONFIG, 'Value to use with the --db-config argument')
     stringParam('KCI_CORE_URL', KCI_CORE_URL, 'URL of the kernelci-core repository.')
     stringParam('KCI_CORE_BRANCH', KCI_CORE_BRANCH, 'Name of the branch to use in the kernelci-core repository.')

--- a/jobs/bisect.jpl
+++ b/jobs/bisect.jpl
@@ -63,6 +63,8 @@ KCI_API_URL (https://api.kernelci.org)
   URL of the KernelCI backend API
 KCI_API_TOKEN_ID
   Identifier of the KernelCI backend API token stored in Jenkins
+KCI_STORAGE_CONFIG (storage.kernelci.org)
+  Name of the KernelCI storage configuration
 KCI_STORAGE_URL (https://storage.kernelci.org/)
   URL of the KernelCI storage server
 KCI_DB_CONFIG (kernelci.org)
@@ -302,9 +304,8 @@ make_kselftest \
 kci_build \
 push_kernel \
 --kdir=${kdir} \
---db-token=${SECRET} \
---api=${params.KCI_API_URL} \
---db-config=${KCI_DB_CONFIG} \
+--storage-config=${KCI_STORAGE_CONFIG} \
+--storage-cred=${SECRET} \
 --output=${output} \
 """)
     }


### PR DESCRIPTION
Use the new kci_build --storage-config / --storage-cred arguments with the KCI_STORAGE_CONFIG job parameter.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>