### PR TITLE
jobs/*: replace --lab-* arguments with --runtime-*

### DIFF
--- a/jobs/bisect.jpl
+++ b/jobs/bisect.jpl
@@ -338,10 +338,10 @@ def fetchLabInfo() {
                 sh(script: """\
 kci_test \
 get_lab_info \
---lab-config=${params.LAB} \
---lab-json=${env._LAB_JSON} \
+--runtime-config=${params.LAB} \
+--runtime-json=${env._LAB_JSON} \
 --user=kernel-ci \
---lab-token=${SECRET} \
+--runtime-token=${SECRET} \
 """)
                 retry = 0
             }
@@ -377,10 +377,10 @@ generate \
 --install-path=. \
 --storage=${params.KCI_STORAGE_URL} \
 --db-config=${KCI_DB_CONFIG} \
---lab-json=${env._LAB_JSON} \
---lab-config=${params.LAB} \
+--runtime-json=${env._LAB_JSON} \
+--runtime-config=${params.LAB} \
 --user=kernel-ci \
---lab-token=${SECRET} \
+--runtime-token=${SECRET} \
 --callback-id=${params.LAVA_CALLBACK} \
 --callback-url=${hook.getURL()} \
 --callback-dataset=results \
@@ -393,9 +393,9 @@ generate \
         sh(script: """ \
 kci_test \
 submit \
---lab-config=${params.LAB} \
+--runtime-config=${params.LAB} \
 --user=kernel-ci \
---lab-token=${SECRET} \
+--runtime-token=${SECRET} \
 --jobs=job.yaml \
 """)
     }

--- a/jobs/build-trigger.jpl
+++ b/jobs/build-trigger.jpl
@@ -189,8 +189,8 @@ def getLabsWithTests(build_job_name, number, labs) {
 #!/bin/sh -e
 kci_test \
 list_jobs \
---lab-config=${lab} \
---lab-json=${lab_json} \
+--runtime-config=${lab} \
+--runtime-json=${lab_json} \
 --install-path=${artifacts} \
 """, returnStdout: true).trim()
 
@@ -335,10 +335,10 @@ node("docker && build-trigger") {
                             sh(script: """\
 kci_test \
 get_lab_info \
---lab-config=${lab} \
---lab-json=${lab_json} \
+--runtime-config=${lab} \
+--runtime-json=${lab_json} \
 --user=kernel-ci \
---lab-token=${SECRET} \
+--runtime-token=${SECRET} \
 """)
                         }
                         labs.add(lab)

--- a/jobs/test-runner.jpl
+++ b/jobs/test-runner.jpl
@@ -71,11 +71,11 @@ def generateJobs(lab, artifacts, jobs_dir)
 kci_test \
 generate \
 --install-path=${artifacts} \
---lab-json=${artifacts}/${lab}.json \
+--runtime-json=${artifacts}/${lab}.json \
 --storage=${params.KCI_STORAGE_URL} \
---lab-config=${lab} \
+--runtime-config=${lab} \
 --user=kernel-ci \
---lab-token=${SECRET} \
+--runtime-token=${SECRET} \
 --output=${jobs_dir} \
 --callback-id=${params.CALLBACK_ID} \
 --callback-url=${params.CALLBACK_URL} \
@@ -91,9 +91,9 @@ def submitJobs(lab, jobs_dir)
         sh(script: """\
 kci_test \
 submit \
---lab-config=${lab} \
+--runtime-config=${lab} \
 --user=kernel-ci \
---lab-token=${SECRET} \
+--runtime-token=${SECRET} \
 --jobs=${jobs_dir}/* \
 """)
     }


### PR DESCRIPTION
Update all the jobs to use the new --runtime-* command line arguments.

Depends on https://github.com/kernelci/kernelci-core/pull/1737