### PR TITLE
CHROMEOS rootfs-builder.jpl: Add missing kernelci fragment

### DIFF
--- a/jobs/rootfs-builder.jpl
+++ b/jobs/rootfs-builder.jpl
@@ -105,7 +105,7 @@ node("debos && docker") {
     def docker_image = "${params.DOCKER_BASE}${rootfs_type}:kernelci"
 
     if (rootfs_type == "chromiumos") {
-        docker_image = "kernelci/cros-sdk"
+        docker_image = "kernelci/cros-sdk:kernelci"
     }
 
     print("""\


### PR DESCRIPTION
We are generating docker image with :kernelci fragment, also kernelci-core doesn't work standalone anymore, as it need some dependencies.