### PR TITLE
rootfs-builder.jpl: Fix build issues on latest version of Ubuntu runner

### DIFF
--- a/jobs/rootfs-builder.jpl
+++ b/jobs/rootfs-builder.jpl
@@ -108,7 +108,7 @@ node("debos && docker") {
     }
 
     j.dockerPullWithRetry(docker_image).
-        inside(" --privileged --device /dev/kvm --init ") {
+        inside(" --privileged --device /dev/kvm --init --volume /dev/shm --tmpfs /dev/shm:rw,nosuid,nodev,exec") {
 
         stage("Build") {
             timeout(time: 8, unit: 'HOURS') {


### PR DESCRIPTION
Fixes https://github.com/kernelci/kernelci-core/issues/1992

Tested at https://bot.staging.kernelci.org/job/rootfs-builder/564/console
Fix suggested at: https://github.com/go-debos/debos/issues/309