### PR TITLE
temporarily disabling bisections

### DIFF
--- a/jobs.groovy
+++ b/jobs.groovy
@@ -278,6 +278,7 @@ pipelineJob('rootfs-builder') {
   }
 }
 
+/* temporarily disabled
 pipelineJob('lava-bisection') {
   definition {
     cpsScm {
@@ -333,4 +334,4 @@ pipelineJob('lava-bisection') {
     stringParam('LABS_WHITELIST', KCI_BISECTION_LABS_WHITELIST, 'If defined, jobs will abort if the LAB is not on that list.')
     stringParam('TREES_WHITELIST', KCI_BISECTION_TREES_WHITELIST, 'If defined, jobs will abort if the KERNEL_TREE is not on that list.')
   }
-}
+} */


### PR DESCRIPTION
Bisections are currently disabled due to resource constraints.  We expect this to be temporary.