### PR TITLE
feat(test-runner.jpl): Try to skip lab tests

### DIFF
--- a/jobs/test-runner.jpl
+++ b/jobs/test-runner.jpl
@@ -112,6 +112,10 @@ node("docker && test-runner") {
     Container: ${docker_image}""")
 
     j.dockerPullWithRetry(docker_image).inside('--init') {
+        stage("Skip") {
+            print("Legacy setup wont execute tests")
+            return
+        }
         stage("Init") {
             sh(script: "rm -rf ${artifacts}")
             sh(script: "rm -rf ${jobs_dir}")


### PR DESCRIPTION
On legacy this is just slowing down things.
Only thing we need for a while is android builds.